### PR TITLE
FIX mark to deploy using latest commit from PR

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -141,7 +141,7 @@ def mark_to_deploy(pr_number):
     }
     url = "https://api.github.com/repos/gisce/erp/pulls/%s/commits" % pr_number
     r = requests.get(url, headers=headers)
-    commit = json.loads(r.text)[0]['sha']
+    commit = json.loads(r.text)[-1]['sha']
     host = run("uname -n")
     payload = {
         'ref': commit, 'task': 'deploy', 'auto_merge': False,

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -139,9 +139,10 @@ def mark_to_deploy(pr_number):
         'Accept': 'application/vnd.github.cannonball-preview+json',
         'Authorization': 'token %s' % github_config()['token']
     }
-    url = "https://api.github.com/repos/gisce/erp/pulls/%s/commits" % pr_number
+    url = "https://api.github.com/repos/gisce/erp/pulls/%s" % pr_number
     r = requests.get(url, headers=headers)
-    commit = json.loads(r.text)[-1]['sha']
+    pull = json.loads(r.text)
+    commit = pull['head']['sha']
     host = run("uname -n")
     payload = {
         'ref': commit, 'task': 'deploy', 'auto_merge': False,


### PR DESCRIPTION
After large email talking with Github Team

> 
> Hi Guillem,
> 
> Thanks for hanging in there. After conferring with another colleague about this, I'd like to share our findings with you.
> 
> When you create a deployment for some commit (let's call it X), a deployment issue event is created on all pull requests that have X as the head commit.
> 
> In gisce/erp#3626, it looks like you created a deployment on the oldest commit, be68d35, instead of the head commit, 83ab503:
> 
> https://api.github.com/repos/gisce/erp/deployments/10929258
> 
> GitHub doesn't currently create an issue event for this because be68d35 isn't the head commit.
> 
> The behavior you've observed is expected for now, but I can see how this can be confusing.
> 
> I've opened an issue internally so the team working on this can document this behavior in our help documentation so others can understand when deployments should appear in the pull request timeline. Though we can't promise an ETA for if/when this will be updated, we appreciate you writing in about this.
> 
> With that -- thanks so much for writing in about this!

I change a method to get the latest commit, because all commits from PR has 250 commits limit. On PR info we have `head` key with `sha` commit.
