### PR TITLE
Add function to set status

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -41,5 +41,18 @@ def check_pr(pr, host):
     check_pr_task = WrappedCallableTask(fabfile.check_pr)
     execute(check_pr_task, pr, host=url.hostname)
 
+@click.command(name='status_pr')
+@click.option('--deploy-id', help='Deploy id to mark')
+@click.option('--status', help='Status to set.', default='success',
+              type=click.Choice(['success', 'error', 'failure']))
+def status_pr(deploy_id, status):
+    from apply_pr import fabfile
+
+    log_level = getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper())
+    logging.basicConfig(level=log_level)
+
+    mark_deploy_status = WrappedCallableTask(fabfile.mark_deploy_status)
+    execute(mark_deploy_status, deploy_id, status)
+
 if __name__ == '__main__':
     apply_pr()

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -1,4 +1,6 @@
-from __future__ import with_statement
+from __future__ import (
+    with_statement, absolute_import, unicode_literals, print_function
+)
 import json
 import logging
 import os
@@ -253,4 +255,3 @@ def check_pr(pr_number):
         print(message.format(num_commit, first_line))
 
     return result
-

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         [console_scripts]
         apply_pr=apply_pr.cli:apply_pr
         check_pr=apply_pr.cli:check_pr
+        status_pr=apply_pr.cli:status_pr
     ''',
     install_requires=[
         'fabric',


### PR DESCRIPTION
This pr add two functionalities:
1. Update the status from a deploy
`$ status_pr --deploy-id=3424324 --status=success`
2. Get the deployments from the current branch
`$ fab -f apply_pr/fabfile get_deploys:PR_NUMBER`

Maybe in a future create a command line util for the last point, but we need a refactor to get only a one apply_pr and subcomands