### PR TITLE
Add mark_deployed task

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -411,6 +411,11 @@ def apply_pr(pr_number, from_number=0, from_commit=None, skip_upload=False):
 
 
 @task
+def mark_deployed(pr_number):
+    deploy_id = mark_to_deploy(pr_number)
+    mark_deploy_status(deploy_id, 'success')
+
+@task
 def check_pr(pr_number):
     result = OrderedDict()
     repo = github_config(repository='gisce/erp')['repository']


### PR DESCRIPTION
Some times the PR are not marked as deployed due to some failure or maybe we need to mark a PR as deployed, so this new task helps.