### PR TITLE
ADD usage for any repository of any owner for any remote path

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -24,14 +24,14 @@ def configure_logging():
               default=None, show_default=True)
 @click.option("--force-hostname", help="Force hostname",
               default=False, show_default=True)
-@click.option('--company', help='GitHub company name',
+@click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repo', help='GitHub repository name',
               default='erp', show_default=True)
 @click.option('--src', help='Remote src path',
               default='/home/erp/src', show_default=True)
 def apply_pr(
-        pr, host, from_number, from_commit, force_hostname, company, repo, src
+        pr, host, from_number, from_commit, force_hostname, owner, repo, src
 ):
     from apply_pr.version import check_version
     check_version()
@@ -47,7 +47,7 @@ def apply_pr(
     apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
     execute(
         apply_pr_task, pr, from_number, from_commit, force_hostname,
-        src=src, company=company, repository=repo,
+        src=src, owner=owner, repository=repo,
         host=url.hostname
     )
 
@@ -55,13 +55,13 @@ def apply_pr(
 @click.command(name='check_pr')
 @click.option('--pr', help='Pull request to check', required=True)
 @click.option('--host', help='Host to check', required=True)
-@click.option('--company', help='GitHub company name',
+@click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repo', help='GitHub repository name',
               default='erp', show_default=True)
 @click.option('--src', help='Remote src path',
               default='/home/erp/src', show_default=True)
-def check_pr(pr, src, company, repo, host):
+def check_pr(pr, src, owner, repo, host):
     from apply_pr import fabfile
 
     url = urlparse(host)
@@ -72,36 +72,36 @@ def check_pr(pr, src, company, repo, host):
 
     check_pr_task = WrappedCallableTask(fabfile.check_pr)
     execute(check_pr_task, pr,
-            src=src, company=company, repository=repo, host=url.hostname)
+            src=src, owner=owner, repository=repo, host=url.hostname)
 
 
 @click.command(name='status_pr')
 @click.option('--deploy-id', help='Deploy id to mark')
 @click.option('--status', type=click.Choice(['success', 'error', 'failure']),
               help='Status to set', default='success', show_default=True)
-@click.option('--company', help='GitHub company name',
+@click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repo', help='GitHub repository name',
               default='erp', show_default=True)
-def status_pr(deploy_id, status, company, repo):
+def status_pr(deploy_id, status, owner, repo):
     from apply_pr import fabfile
 
     configure_logging()
 
     mark_deploy_status = WrappedCallableTask(fabfile.mark_deploy_status)
     execute(mark_deploy_status, deploy_id, status,
-            company=company, repository=repo)
+            owner=owner, repository=repo)
 
 
 @click.command(name='check_prs_status')
 @click.option('--prs', help='List of pull request separated by space (by default)', required=True)
 @click.option('--separator', help='Character separator of list by default is space',
               default=' ', required=True, show_default=True)
-@click.option('--company', help='GitHub company name',
+@click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repo', help='GitHub repository name',
               default='erp', show_default=True)
-def check_prs_status(prs, separator, company, repo):
+def check_prs_status(prs, separator, owner, repo):
     from apply_pr import fabfile
 
     log_level = getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper())
@@ -109,7 +109,7 @@ def check_prs_status(prs, separator, company, repo):
 
     check_pr_task = WrappedCallableTask(fabfile.prs_status)
     execute(check_pr_task, prs,
-            company=company,
+            owner=owner,
             repository=repo,
             separator=separator)
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -20,11 +20,16 @@ def configure_logging():
 @click.option("--pr", help="Pull request to apply", required=True)
 @click.option("--host", help="Host to apply", required=True)
 @click.option("--from-number", help="From commit number", default=0)
-@click.option("--from-commit", help="From commit hash (included)", default=None)
-@click.option("--force-hostname", help="Force hostname", default=False)
-@click.option("--company", default='gisce', help='GitHub company name')
-@click.option("--repo", default='erp', help='GitHub repository name')
-@click.option("--src", default='/home/erp/src', help='GitHub repository name')
+@click.option("--from-commit", help="From commit hash (included)",
+              default=None, show_default=True)
+@click.option("--force-hostname", help="Force hostname",
+              default=False, show_default=True)
+@click.option('--company', help='GitHub company name',
+              default='gisce', show_default=True)
+@click.option('--repo', help='GitHub repository name',
+              default='erp', show_default=True)
+@click.option('--src', help='Remote src path',
+              default='/home/erp/src', show_default=True)
 def apply_pr(
         pr, host, from_number, from_commit, force_hostname, company, repo, src
 ):
@@ -50,9 +55,12 @@ def apply_pr(
 @click.command(name='check_pr')
 @click.option('--pr', help='Pull request to check', required=True)
 @click.option('--host', help='Host to check', required=True)
-@click.option("--src", default='/home/erp/src', help='GitHub repository name')
-@click.option("--company", default='gisce', help='GitHub company name')
-@click.option("--repo", default='erp', help='GitHub repository name')
+@click.option('--company', help='GitHub company name',
+              default='gisce', show_default=True)
+@click.option('--repo', help='GitHub repository name',
+              default='erp', show_default=True)
+@click.option('--src', help='Remote src path',
+              default='/home/erp/src', show_default=True)
 def check_pr(pr, src, company, repo, host):
     from apply_pr import fabfile
 
@@ -69,10 +77,12 @@ def check_pr(pr, src, company, repo, host):
 
 @click.command(name='status_pr')
 @click.option('--deploy-id', help='Deploy id to mark')
-@click.option('--status', help='Status to set.', default='success',
-              type=click.Choice(['success', 'error', 'failure']))
-@click.option("--company", default='gisce', help='GitHub company name')
-@click.option("--repo", default='erp', help='GitHub repository name')
+@click.option('--status', type=click.Choice(['success', 'error', 'failure']),
+              help='Status to set', default='success', show_default=True)
+@click.option('--company', help='GitHub company name',
+              default='gisce', show_default=True)
+@click.option('--repo', help='GitHub repository name',
+              default='erp', show_default=True)
 def status_pr(deploy_id, status, company, repo):
     from apply_pr import fabfile
 
@@ -84,10 +94,13 @@ def status_pr(deploy_id, status, company, repo):
 
 
 @click.command(name='check_prs_status')
-@click.option('--prs', help='List of pull request separated by space(by default)', required=True)
-@click.option('--separator', help='Character separator of list by default is space', default=' ', required=True)
-@click.option("--company", default='gisce', help='GitHub company name')
-@click.option("--repo", default='erp', help='GitHub repository name')
+@click.option('--prs', help='List of pull request separated by space (by default)', required=True)
+@click.option('--separator', help='Character separator of list by default is space',
+              default=' ', required=True, show_default=True)
+@click.option('--company', help='GitHub company name',
+              default='gisce', show_default=True)
+@click.option('--repo', help='GitHub repository name',
+              default='erp', show_default=True)
 def check_prs_status(prs, separator, company, repo):
     from apply_pr import fabfile
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -22,7 +22,12 @@ def configure_logging():
 @click.option("--from-number", help="From commit number", default=0)
 @click.option("--from-commit", help="From commit hash (included)", default=None)
 @click.option("--force-hostname", help="Force hostname", default=False)
-def apply_pr(pr, host, from_number, from_commit, force_hostname):
+@click.option("--company", default='gisce', help='GitHub company name')
+@click.option("--repo", default='erp', help='GitHub repository name')
+@click.option("--src", default='/home/erp/src', help='GitHub repository name')
+def apply_pr(
+        pr, host, from_number, from_commit, force_hostname, company, repo, src
+):
     from apply_pr.version import check_version
     check_version()
 
@@ -35,13 +40,20 @@ def apply_pr(pr, host, from_number, from_commit, force_hostname):
     configure_logging()
 
     apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
-    execute(apply_pr_task, pr, from_number, from_commit, host=url.hostname, hostname=force_hostname)
+    execute(
+        apply_pr_task, pr, from_number, from_commit, force_hostname,
+        src=src, company=company, repository=repo,
+        host=url.hostname
+    )
 
 
 @click.command(name='check_pr')
 @click.option('--pr', help='Pull request to check', required=True)
 @click.option('--host', help='Host to check', required=True)
-def check_pr(pr, host):
+@click.option("--src", default='/home/erp/src', help='GitHub repository name')
+@click.option("--company", default='gisce', help='GitHub company name')
+@click.option("--repo", default='erp', help='GitHub repository name')
+def check_pr(pr, src, company, repo, host):
     from apply_pr import fabfile
 
     url = urlparse(host)
@@ -51,33 +63,43 @@ def check_pr(pr, host):
     configure_logging()
 
     check_pr_task = WrappedCallableTask(fabfile.check_pr)
-    execute(check_pr_task, pr, host=url.hostname)
+    execute(check_pr_task, pr,
+            src=src, company=company, repository=repo, host=url.hostname)
 
 
 @click.command(name='status_pr')
 @click.option('--deploy-id', help='Deploy id to mark')
 @click.option('--status', help='Status to set.', default='success',
               type=click.Choice(['success', 'error', 'failure']))
-def status_pr(deploy_id, status):
+@click.option("--company", default='gisce', help='GitHub company name')
+@click.option("--repo", default='erp', help='GitHub repository name')
+def status_pr(deploy_id, status, company, repo):
     from apply_pr import fabfile
 
     configure_logging()
 
     mark_deploy_status = WrappedCallableTask(fabfile.mark_deploy_status)
-    execute(mark_deploy_status, deploy_id, status)
+    execute(mark_deploy_status, deploy_id, status,
+            company=company, repository=repo)
 
 
 @click.command(name='check_prs_status')
 @click.option('--prs', help='List of pull request separated by space(by default)', required=True)
 @click.option('--separator', help='Character separator of list by default is space', default=' ', required=True)
-def check_prs_status(prs, separator):
+@click.option("--company", default='gisce', help='GitHub company name')
+@click.option("--repo", default='erp', help='GitHub repository name')
+def check_prs_status(prs, separator, company, repo):
     from apply_pr import fabfile
 
     log_level = getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper())
     logging.basicConfig(level=log_level)
 
     check_pr_task = WrappedCallableTask(fabfile.prs_status)
-    execute(check_pr_task, prs, separator=separator)
+    execute(check_pr_task, prs,
+            company=company,
+            repository=repo,
+            separator=separator)
+
 
 if __name__ == '__main__':
     apply_pr()

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -26,12 +26,13 @@ def configure_logging():
               default=False, show_default=True)
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
-@click.option('--repo', help='GitHub repository name',
+@click.option('--repository', help='GitHub repository name',
               default='erp', show_default=True)
 @click.option('--src', help='Remote src path',
               default='/home/erp/src', show_default=True)
 def apply_pr(
-        pr, host, from_number, from_commit, force_hostname, owner, repo, src
+        pr, host, from_number, from_commit, force_hostname,
+        owner, repository, src
 ):
     from apply_pr.version import check_version
     check_version()
@@ -47,7 +48,7 @@ def apply_pr(
     apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
     execute(
         apply_pr_task, pr, from_number, from_commit, force_hostname,
-        src=src, owner=owner, repository=repo,
+        src=src, owner=owner, repository=repository,
         host=url.hostname
     )
 
@@ -57,11 +58,11 @@ def apply_pr(
 @click.option('--host', help='Host to check', required=True)
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
-@click.option('--repo', help='GitHub repository name',
+@click.option('--repository', help='GitHub repository name',
               default='erp', show_default=True)
 @click.option('--src', help='Remote src path',
               default='/home/erp/src', show_default=True)
-def check_pr(pr, src, owner, repo, host):
+def check_pr(pr, src, owner, repository, host):
     from apply_pr import fabfile
 
     url = urlparse(host)
@@ -72,7 +73,7 @@ def check_pr(pr, src, owner, repo, host):
 
     check_pr_task = WrappedCallableTask(fabfile.check_pr)
     execute(check_pr_task, pr,
-            src=src, owner=owner, repository=repo, host=url.hostname)
+            src=src, owner=owner, repository=repository, host=url.hostname)
 
 
 @click.command(name='status_pr')
@@ -81,27 +82,29 @@ def check_pr(pr, src, owner, repo, host):
               help='Status to set', default='success', show_default=True)
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
-@click.option('--repo', help='GitHub repository name',
+@click.option('--repository', help='GitHub repository name',
               default='erp', show_default=True)
-def status_pr(deploy_id, status, owner, repo):
+def status_pr(deploy_id, status, owner, repository):
     from apply_pr import fabfile
 
     configure_logging()
 
     mark_deploy_status = WrappedCallableTask(fabfile.mark_deploy_status)
     execute(mark_deploy_status, deploy_id, status,
-            owner=owner, repository=repo)
+            owner=owner, repository=repository)
 
 
 @click.command(name='check_prs_status')
-@click.option('--prs', help='List of pull request separated by space (by default)', required=True)
-@click.option('--separator', help='Character separator of list by default is space',
+@click.option('--prs', required=True,
+              help='List of pull request separated by space (by default)')
+@click.option('--separator',
+              help='Character separator of list by default is space',
               default=' ', required=True, show_default=True)
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
-@click.option('--repo', help='GitHub repository name',
+@click.option('--repository', help='GitHub repository name',
               default='erp', show_default=True)
-def check_prs_status(prs, separator, owner, repo):
+def check_prs_status(prs, separator, owner, repository):
     from apply_pr import fabfile
 
     log_level = getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper())
@@ -110,7 +113,7 @@ def check_prs_status(prs, separator, owner, repo):
     check_pr_task = WrappedCallableTask(fabfile.prs_status)
     execute(check_pr_task, prs,
             owner=owner,
-            repository=repo,
+            repository=repository,
             separator=separator)
 
 

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -44,9 +44,13 @@ if config.get('logging'):
 
 
 @task
-def upload_patches(pr_number, from_commit=None):
+def upload_patches(
+    pr_number, from_commit=None, src='/home/erp/src/', repository='erp'
+):
     temp_dir = '/tmp/%s' % pr_number
-    remote_dir = '/home/erp/src/erp/patches/{}'.format(pr_number)
+    remote_dir = '{}/{}/patches/{}'.format(
+        src, repository, pr_number
+    )
     sudo("mkdir -p %s" % remote_dir)
     sudo("mkdir -p %s" % temp_dir)
     patches = [p for p in local(
@@ -72,7 +76,9 @@ def upload_patches(pr_number, from_commit=None):
 
 
 @task
-def apply_remote_patches(name, from_patch=0):
+def apply_remote_patches(
+    name, from_patch=0, src='/home/erp/src/', repository='erp'
+):
     from_commit = None
     if isinstance(from_patch, basestring) and len(from_patch) == 40:
         from_commit = from_patch
@@ -83,8 +89,9 @@ def apply_remote_patches(name, from_patch=0):
         logger.info('Applying from number {}'.format(from_patch))
     with settings(warn_only=True, sudo_user='erp'):
         with hide('output'):
-            patches = sudo("ls -1 /home/erp/src/erp/patches/%s/*.patch" % name)
-
+            patches = sudo("ls -1 {}/{}/patches/{}/*.patch".format(
+                src, repository, name
+            ))
         patches_to_apply = []
         for patch in patches.split():
             if from_patch:
@@ -102,7 +109,7 @@ def apply_remote_patches(name, from_patch=0):
             patches_to_apply.append(patch)
 
         if patches_to_apply:
-            with cd("/home/erp/src/erp"):
+            with cd("{}/{}".format(src, repository)):
                 git_am = GitApplier(patches_to_apply)
                 git_am.run()
 
@@ -216,9 +223,11 @@ class PatchFile(object):
 
 
 @task
-def find_from_to_commits(pr_number):
+def find_from_to_commits(pr_number, company='gisce', repository='erp'):
     headers = {'Authorization': 'token %s' % github_config()['token']}
-    url = "https://api.github.com/repos/gisce/erp/pulls/%s" % pr_number
+    url = "https://api.github.com/repos/{}/{}/pulls/{}".format(
+        company, repository, pr_number
+    )
     r = requests.get(url, headers=headers)
     if r.status_code != 200:
         abort("Unable to get info from the pull request")
@@ -245,8 +254,11 @@ def export_patches_from_git(from_commit, to_commit, pr_number):
 
 
 @task
-def export_patches_from_github(pr_number, from_commit=None):
-    repo = github_config(repository='gisce/erp')['repository']
+def export_patches_from_github(
+    pr_number, from_commit=None, company='gisce', repository='erp'
+):
+    repo = github_config(
+        repository='{}/{}'.format(company, repository))['repository']
     patch_folder = "deploy/patches/%s" % pr_number
     local("mkdir -p %s" % patch_folder)
     logger.info('Exporting patches from GitHub')
@@ -287,13 +299,17 @@ def export_patches_from_github(pr_number, from_commit=None):
 
 
 @task
-def mark_to_deploy(pr_number, hostname=False):
+def mark_to_deploy(
+    pr_number, hostname=False, company='gisce', repository='erp'
+):
     logger.info('Marking as deployed on GitHub')
     headers = {
         'Accept': 'application/vnd.github.cannonball-preview+json',
         'Authorization': 'token %s' % github_config()['token']
     }
-    url = "https://api.github.com/repos/gisce/erp/pulls/%s" % pr_number
+    url = "https://api.github.com/repos/{}/{}/pulls/{}".format(
+        company, repository, pr_number
+    )
     r = requests.get(url, headers=headers)
     pull = json.loads(r.text)
     commit = pull['head']['sha']
@@ -312,7 +328,9 @@ def mark_to_deploy(pr_number, hostname=False):
             'host': host
         }
     }
-    url = "https://api.github.com/repos/gisce/erp/deployments"
+    url = "https://api.github.com/repos/{}/{}/deployments".format(
+        company, repository
+    )
     r = requests.post(url, data=json.dumps(payload), headers=headers)
     res = json.loads(r.text)
     if not 'id' in res:
@@ -324,16 +342,20 @@ def mark_to_deploy(pr_number, hostname=False):
 
 
 @task
-def get_deploys(pr_number):
+def get_deploys(pr_number, company='gisce', repository='erp'):
     headers = {
         'Accept': 'application/vnd.github.cannonball-preview+json',
         'Authorization': 'token %s' % github_config()['token']
     }
-    url = "https://api.github.com/repos/gisce/erp/pulls/%s" % pr_number
+    url = "https://api.github.com/repos/{}/{}/pulls/{}".format(
+        company, repository, pr_number
+    )
     r = requests.get(url, headers=headers)
     pull = json.loads(r.text)
     commit = pull['head']['sha']
-    url = "https://api.github.com/repos/gisce/erp/deployments?ref={}".format(commit)
+    url = "https://api.github.com/repos/{}/{}/deployments?ref={}".format(
+        company, repository, commit
+    )
     r = requests.get(url, headers=headers)
     res = json.loads(r.text)
     for deployment in res:
@@ -346,7 +368,10 @@ def get_deploys(pr_number):
 
 
 @task
-def mark_deploy_status(deploy_id, state='success', description=None):
+def mark_deploy_status(
+    deploy_id, state='success', description=None,
+    company='gisce', repository='erp'
+):
     if not deploy_id:
         return
     logger.info('Marking as deployed %s on GitHub' % state)
@@ -355,29 +380,37 @@ def mark_deploy_status(deploy_id, state='success', description=None):
         'Authorization': 'token %s' % github_config()['token']
     }
 
-    url = "https://api.github.com/repos/gisce/erp/deployments/%s/statuses"
+    url = "https://api.github.com/repos/{}/{}/deployments/{}/statuses".format(
+        company, repository, deploy_id
+    )
     payload = {'state': state}
     if description is not None:
         payload['description'] = description
-    r = requests.post(url % deploy_id, data=json.dumps(payload),
-                      headers=headers)
+    r = requests.post(url, data=json.dumps(payload), headers=headers)
     logger.info('Deploy %s marked as %s' % (deploy_id, state))
 
 
 @task
-def export_patches_pr(pr_number):
+def export_patches_pr(pr_number, company='gisce', repository='erp'):
     local("mkdir -p deploy/patches/%s" % pr_number)
-    from_commit, to_commit, branch = find_from_to_commits(pr_number)
+    from_commit, to_commit, branch = find_from_to_commits(
+        pr_number, company=company, repository=repository
+    )
     if branch is None:
-        export_patches_from_github(pr_number)
+        export_patches_from_github(
+            pr_number, company=company, repository=repository
+        )
     else:
-        export_patches_from_git(from_commit, to_commit, pr_number)
+        export_patches_from_git(
+            from_commit, to_commit, pr_number,
+            company=company, repository=repository
+        )
 
 
 @task
-def check_is_rolling():
+def check_is_rolling(src='/home/erp/src', repository='erp'):
     with settings(hide('everything'), sudo_user='erp', warn_only=True):
-        with cd("/home/erp/src/erp"):
+        with cd("{}/{}".format(src, repository)):
             res = sudo("git branch | grep '* rolling'")
             if res.return_code:
                 message = "The repository is not in rolling mode"
@@ -386,50 +419,82 @@ def check_is_rolling():
 
 
 @task
-def apply_pr(pr_number, from_number=0, from_commit=None, skip_upload=False, hostname=False):
+def apply_pr(
+        pr_number, from_number=0, from_commit=None, skip_upload=False,
+        hostname=False, src='/home/erp/src', company='gisce', repository='erp'
+):
     try:
-        check_is_rolling()
+        check_is_rolling(src=src, repository=repository)
     except NetworkError as e:
         logger.error('Error connecting to specified host')
         logger.error(e)
         raise
-    deploy_id = mark_to_deploy(pr_number, hostname=hostname)
+    deploy_id = mark_to_deploy(pr_number,
+                               hostname=hostname,
+                               company=company,
+                               repository=repository)
     if not deploy_id:
         tqdm.write(colors.magenta(
             'No deploy id! you must mark the pr manually'
         ))
     try:
-        mark_deploy_status(deploy_id, 'pending')
+        mark_deploy_status(deploy_id,
+                           state='pending',
+                           company=company,
+                           repository=repository)
         tqdm.write(colors.yellow("Marking to deploy ({}) \U0001F680".format(
             deploy_id
         )))
         if not skip_upload:
             pass
-            export_patches_from_github(pr_number, from_commit)
-            upload_patches(pr_number, from_commit)
+            export_patches_from_github(pr_number,
+                                       from_commit,
+                                       company=company,
+                                       repository=repository)
+            upload_patches(pr_number,
+                           from_commit,
+                           src=src,
+                           repository=repository)
         if from_commit:
             from_ = from_commit
         else:
             from_ = from_number
         tqdm.write(colors.yellow("Applying patches \U0001F648"))
-        apply_remote_patches(pr_number, from_)
-        mark_deploy_status(deploy_id, 'success')
+        apply_remote_patches(pr_number,
+                             from_,
+                             src=src,
+                             repository=repository)
+        mark_deploy_status(deploy_id,
+                           state='success',
+                           company=company,
+                           repository=repository)
         tqdm.write(colors.green("Deploy success \U0001F680"))
     except Exception as e:
         logger.error(e)
-        mark_deploy_status(deploy_id, 'error', description=e.message)
+        mark_deploy_status(deploy_id,
+                           state='error',
+                           description=e.message,
+                           company=company,
+                           repository=repository)
         tqdm.write(colors.red("Deploy failure \U0001F680"))
 
 
 @task
-def mark_deployed(pr_number):
-    deploy_id = mark_to_deploy(pr_number)
-    mark_deploy_status(deploy_id, 'success')
+def mark_deployed(pr_number, hostname=False, company='gisce', repository='erp'):
+    deploy_id = mark_to_deploy(pr_number,
+                               hostname=hostname,
+                               company=company,
+                               repository=repository)
+    mark_deploy_status(deploy_id,
+                       state='success',
+                       company=company,
+                       repository=repository)
 
 @task
-def check_pr(pr_number):
+def check_pr(pr_number, src='/home/erp/src', company='gisce', repository='erp'):
     result = OrderedDict()
-    repo = github_config(repository='gisce/erp')['repository']
+    repo = github_config(
+        repository='{}/{}'.format(company, repository))['repository']
     logger.info('Exporting patches from GitHub')
     headers = {'Authorization': 'token %s' % github_config()['token']}
     # Pagination documentation: https://developer.github.com/v3/#pagination
@@ -439,7 +504,7 @@ def check_pr(pr_number):
     commits = json.loads(r.text)
 
     with settings(warn_only=True, sudo_user='erp'):
-        with cd("/home/erp/src/erp"):
+        with cd("{}/{}".format(src, repository)):
             for commit in commits:
                 fh = StringIO.StringIO()
                 commit_message = (
@@ -466,7 +531,7 @@ def check_pr(pr_number):
     return result
 
 @task
-def prs_status(prs, separator=' '):
+def prs_status(prs, separator=' ', company='gisce', repository='erp'):
     logger.info('Marking as deployed on GitHub')
     headers = {
         'Accept': 'application/vnd.github.cannonball-preview+json',
@@ -477,7 +542,9 @@ def prs_status(prs, separator=' '):
     PRS = {}
     for pr_number in pr_list:
         try:
-            url = "https://api.github.com/repos/gisce/erp/pulls/%s" % pr_number
+            url = "https://api.github.com/repos/{}/{}/pulls/{}".format(
+                company, repository, pr_number
+            )
             r = requests.get(url, headers=headers)
             pull = json.loads(r.text)
             state_pr = pull['state']

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -314,9 +314,9 @@ def mark_to_deploy(
     pull = json.loads(r.text)
     commit = pull['head']['sha']
     if not hostname:
-       host = run("uname -n")
+        host = run("uname -n")
     else:
-       host = hostname
+        host = hostname
     payload = {
         'ref': commit,
         'task': 'deploy',
@@ -333,7 +333,7 @@ def mark_to_deploy(
     )
     r = requests.post(url, data=json.dumps(payload), headers=headers)
     res = json.loads(r.text)
-    if not 'id' in res:
+    if 'id' not in res:
         logger.info('Not marking deployment in github: %s' % res['message'])
         return 0
     deploy_id = res['id']

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -408,6 +408,16 @@ def export_patches_pr(pr_number, owner='gisce', repository='erp'):
 
 
 @task
+def check_it_exists(src='/home/erp/src', repository='erp'):
+    with settings(hide('everything'), sudo_user='erp', warn_only=True):
+        res = sudo("ls {}/{}".format(src, repository))
+        if res.return_code:
+            message = "The repository does not exist or cannot be found"
+            tqdm.write(colors.red(message))
+            abort(message)
+
+
+@task
 def check_is_rolling(src='/home/erp/src', repository='erp'):
     with settings(hide('everything'), sudo_user='erp', warn_only=True):
         with cd("{}/{}".format(src, repository)):
@@ -424,6 +434,7 @@ def apply_pr(
         hostname=False, src='/home/erp/src', owner='gisce', repository='erp'
 ):
     try:
+        check_it_exists(src=src, repository=repository)
         check_is_rolling(src=src, repository=repository)
     except NetworkError as e:
         logger.error('Error connecting to specified host')

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -45,7 +45,7 @@ if config.get('logging'):
 
 @task
 def upload_patches(
-    pr_number, from_commit=None, src='/home/erp/src/', repository='erp'
+    pr_number, from_commit=None, src='/home/erp/src', repository='erp'
 ):
     temp_dir = '/tmp/%s' % pr_number
     remote_dir = '{}/{}/patches/{}'.format(
@@ -77,7 +77,7 @@ def upload_patches(
 
 @task
 def apply_remote_patches(
-    name, from_patch=0, src='/home/erp/src/', repository='erp'
+    name, from_patch=0, src='/home/erp/src', repository='erp'
 ):
     from_commit = None
     if isinstance(from_patch, basestring) and len(from_patch) == 40:


### PR DESCRIPTION
Add "repository" "company" and "src" options:

- Repository for the repo name (default as "erp")
- Company for the owner name (default as "gisce")
- SRC for the repote path of the source code (default as "/home/erp/src" as it is hardcoded right now)