### PR TITLE
Fix Fabric requirement to v<2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fabric
+fabric<2.0
 osconf
 python-slugify
 requests


### PR DESCRIPTION
Due to the new Fabric API on v2.0 there are import errors invalidating the commands from Click.

Opened the ISSUE #50 to a future improvement of the Fabric usage