### PR TITLE
Improve the "check_prs_status" command

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -101,8 +101,7 @@ def status_pr(deploy_id, status, owner, repository):
               help='Character separator of list by default is space',
               default=' ', required=True, show_default=True)
 @click.option('--version',
-              help='Character separator of list by default is space',
-              default='', required=False)
+              help="Compare with milestone and show if included in prs")
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repository', help='GitHub repository name',

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -100,11 +100,14 @@ def status_pr(deploy_id, status, owner, repository):
 @click.option('--separator',
               help='Character separator of list by default is space',
               default=' ', required=True, show_default=True)
+@click.option('--version',
+              help='Character separator of list by default is space',
+              default='', required=False)
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repository', help='GitHub repository name',
               default='erp', show_default=True)
-def check_prs_status(prs, separator, owner, repository):
+def check_prs_status(prs, separator, version, owner, repository):
     from apply_pr import fabfile
 
     log_level = getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper())
@@ -114,7 +117,8 @@ def check_prs_status(prs, separator, owner, repository):
     execute(check_pr_task, prs,
             owner=owner,
             repository=repository,
-            separator=separator)
+            separator=separator,
+            version=version)
 
 
 @click.command(name='check_prs_status')

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -542,8 +542,8 @@ def check_pr(pr_number, src='/home/erp/src', owner='gisce', repository='erp'):
     return result
 
 @task
-def prs_status(prs, separator=' ', owner='gisce', repository='erp'):
-    logger.info('Marking as deployed on GitHub')
+def prs_status(
+        prs, separator=' ', owner='gisce', repository='erp', version=False):
     headers = {
         'Accept': 'application/vnd.github.cannonball-preview+json',
         'Authorization': 'token %s' % github_config()['token']
@@ -551,7 +551,9 @@ def prs_status(prs, separator=' ', owner='gisce', repository='erp'):
     prs = re.sub('{}+'.format(separator), separator, prs)
     pr_list = prs.split(separator)
     PRS = {}
-    for pr_number in pr_list:
+    ERRORS = []
+    TO_APPLY = []
+    for pr_number in tqdm(pr_list, desc='Getting pr data from Github'):
         try:
             url = "https://api.github.com/repos/{}/{}/pulls/{}".format(
                 owner, repository, pr_number
@@ -561,15 +563,46 @@ def prs_status(prs, separator=' ', owner='gisce', repository='erp'):
             state_pr = pull['state']
             merged_at = pull['merged_at']
             milestone = pull['milestone']['title']
-            message = 'PR {number}=> state {state_pr} merged_at {merged_at} milestone {milestone}'.format(
-                number=pr_number, state_pr=state_pr, merged_at=merged_at, milestone=milestone
+            message = (
+                'PR {number}=>'
+                ' state {state_pr}'
+                ' merged_at {merged_at}'
+                ' milestone {milestone}'.format(
+                    number=pr_number, state_pr=state_pr,
+                    merged_at=merged_at, milestone=milestone
+                )
             )
+            if version:
+                if milestone <= version:
+                    if state_pr != 'closed':
+                        message = colors.yellow(message)
+                        TO_APPLY.append(str(pr_number))
+                    else:
+                        message = colors.green(message)
+                else:
+                    message = colors.red(message)
+                    TO_APPLY.append(str(pr_number))
             PRS.setdefault(milestone, [])
             PRS[milestone] += [message]
         except Exception as e:
-            logger.error('Error PR {0}'.format(pr_number))
-            print('Error PR {0}'.format(pr_number))
-    pprint.pprint(PRS)
+            # logger.error('Error PR {0}'.format(pr_number))
+            err_msg = colors.red(
+                'Error PR {0} : https://github.com/gisce/erp/pull/{0}'.format(
+                    pr_number
+                )
+            )
+            tqdm.write(err_msg)
+            ERRORS.append(err_msg)
+    for milestone in PRS.keys():
+        print('\nMilestone {}'.format(milestone))
+        for prmsg in PRS[milestone]:
+            print('\t{}'.format(prmsg))
+    for prmsg in ERRORS:
+            print('ERR\t{}'.format(prmsg))
+    if version:
+        print(colors.yellow(
+            '\nTo apply: "{}"\n'.format(' '.join(sorted(TO_APPLY)))
+        ))
     return True
 
 @task

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -601,7 +601,7 @@ def prs_status(
             print('ERR\t{}'.format(prmsg))
     if version:
         print(colors.yellow(
-            '\nTo apply: "{}"\n'.format(' '.join(sorted(TO_APPLY)))
+            '\nNot Included: "{}"\n'.format(' '.join(sorted(TO_APPLY)))
         ))
     return True
 


### PR DESCRIPTION
Improve the "check_prs_status" command

- Remove "useless" comment of: "marking as deployed on github" when it wasn't marking anything
- Replace PPrint with for and print
- Use colours if version is provided
- Check version <= milestone of PRs
- ADD a "to apply" list with all the PRS not included in version
- ADD the `--version` parameter to check with PR's milestone

![image](https://user-images.githubusercontent.com/19925414/40542062-c243e6be-601e-11e8-9324-71cf9f083732.png)
