### PR TITLE
Fix hostname parameter using force-hostname option

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -47,7 +47,7 @@ def apply_pr(
 
     apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
     execute(
-        apply_pr_task, pr, from_number, from_commit, force_hostname,
+        apply_pr_task, pr, from_number, from_commit, hostname=force_hostname,
         src=src, owner=owner, repository=repository,
         host=url.hostname
     )


### PR DESCRIPTION
Fix #59

Using `--force-hostname` should mark the Pull Request as deployed on github with the name passed as parameter instead of skipping the upload of the patches.

In the `cli.py` file it is passing `force_hostname` as 4th parameter where it should be the 5th

https://github.com/gisce/apply_pr/blob/a1de8a175e30790950b7ffdd4d59345c3fe22898/apply_pr/cli.py#L49-L53

https://github.com/gisce/apply_pr/blob/d497a9f9e994b39037ea085a9ea73c2f1085c2f7/apply_pr/fabfile.py#L432-L435