### PR TITLE
Use requirements.txt file to install the library

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+with open('requirements.txt', 'r') as f:
+    INSTALL_REQUIRES = f.readlines()
 
 setup(
     name='apply_pr',
@@ -18,12 +20,5 @@ setup(
         check_prs_status=apply_pr.cli:check_prs_status
         create_changelog=apply_pr.cli:create_changelog
     ''',
-    install_requires=[
-        'fabric<2.0',
-        'osconf',
-        'python-slugify',
-        'requests',
-        'click',
-        'tqdm'
-    ]
+    install_requires=INSTALL_REQUIRES
 )


### PR DESCRIPTION
# Description

Write the dependencies of the library in a single `requirements.txt` file in order to avoid changing `setup.py` and `requirements.txt` files when a dependency has changed.

# Things to do
- [x] Read the contents of `requirements.txt` file to install the library
- [x] Add `requirements.txt` to `MANIFEST.in`