### PR TITLE
Add sastre and tailor CLI options for apply_pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ register commands that call the fabric scripts.
 
 The following commands are supported with `sastre`:
 
-| Console Command    | Description                                                         | Wiki page                                |
-|:---------------:   |:--------------------------------------------------------------------|:---------------------------------------- |
-| `deploy`           | Apply a PR to a remote server                                       | [Deploy a pull request](#DEPLOY)         |
-| `check_prs`        | Check the status of the PRs for a set of PRs                        | [Check pull requests status](#CHECK-PRS) |
-| `status`           | Update the status of a deploy into GitHub                           | [Mark deploy status](#STATUS)            |
-| `create_changelog` | Create a chnagelog for the given milestone                          | [Create Changelog](#CREATE-CHANGELOG)    |
-| `check_pr`         | **Deprecated:** Check if the PR's commits are applied on the server | [Check Applied patches](#CHECK-PR)       |
+| Console Command    | Description                                                         | Wiki page                                                                                          |
+|:---------------:   |:--------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
+| `deploy`           | Apply a PR to a remote server                                       | [Deploy a pull request](https://github.com/gisce/apply_pr/wiki/Apply-a-Pull-Request)               |
+| `check_prs`        | Check the status of the PRs for a set of PRs                        | [Check pull requests status](https://github.com/gisce/apply_pr/wiki/Check-pull-requests-status)    |
+| `status`           | Update the status of a deploy into GitHub                           | [Mark deploy status](https://github.com/gisce/apply_pr/wiki/Mark-deploy-status)                    |
+| `create_changelog` | Create a chnagelog for the given milestone                          | [Create Changelog](https://github.com/gisce/apply_pr/wiki/Create-Changelog)                        |
+| `check_pr`         | **Deprecated:** Check if the PR's commits are applied on the server | [Check Applied patches](https://github.com/gisce/apply_pr/wiki/Check-applied-patches-(deprecated)) |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,15 @@ from GitHub and set to the `GITHUB_TOKEN` environment variable.
 This repository uses the [Click](http://click.pocoo.org/5/) package to
 register commands that call the fabric scripts.
 
-The following commands are supported with apply_pr:
+The following commands are supported with `sastre`:
 
-| Console Command | Description                                                                 | Wiki page                                                                             |
-|:---------------:|:----------------------------------------------------------------------------|:--------------------------------------------------------------------------------------|
-|     apply_pr    | Apply a PR to a remote server                                               | [Apply a Pull Request](https://github.com/gisce/apply_pr/wiki/Apply-a-Pull-Request)   |
-|     check_pr    | Check if the PR's commits are applied on the server                         | [Check Applied patches](https://github.com/gisce/apply_pr/wiki/Check-Applied-patches) |
-|    status_pr    | Update the deploy status on GitHub for the PR                               | [Mark deploy status](https://github.com/gisce/apply_pr/wiki/Mark-deploy-status)       |
-| check_prs_status| Check the PRs status (whether they are or not merged and at which milestone)| [Check PRs Status](https://github.com/gisce/apply_pr/wiki/Check-the-PRs-status)       |
-| create_changelog| Creates the changelog for all PRs merged in a milestone                     | [Create Changelog](https://github.com/gisce/apply_pr/wiki/Create-Changelog)           |
-
+| Console Command    | Description                                                         | Wiki page                                |
+|:---------------:   |:--------------------------------------------------------------------|:---------------------------------------- |
+| `deploy`           | Apply a PR to a remote server                                       | [Deploy a pull request](#DEPLOY)         |
+| `check_prs`        | Check the status of the PRs for a set of PRs                        | [Check pull requests status](#CHECK-PRS) |
+| `status`           | Update the status of a deploy into GitHub                           | [Mark deploy status](#STATUS)            |
+| `create_changelog` | Create a chnagelog for the given milestone                          | [Create Changelog](#CREATE-CHANGELOG)    |
+| `check_pr`         | **Deprecated:** Check if the PR's commits are applied on the server | [Check Applied patches](#CHECK-PR)       |
 
 ## Install
 
@@ -35,14 +34,14 @@ pip install apply_pr
 
 **NOTE**: do not include braces on the following commands
 
-### APPLY PR
+### DEPLOY
 
 ```bash
-Usage: apply_pr [OPTIONS]
+Usage: deploy [OPTIONS]
 
 Options:
-  --pr TEXT              Pull request to apply  [required]
-  --host TEXT            Host to apply  [required]
+  --pr TEXT              Pull request to deploy  [required]
+  --host TEXT            Host to where to be deployed  [required]
   --from-number INTEGER  From commit number
   --from-commit TEXT     From commit hash (included)
   --force-hostname TEXT  Force hostname  [default: False]
@@ -52,24 +51,10 @@ Options:
   --help                 Show this message and exit.
 ```
 
-### CHECK PR
+### STATUS
 
 ```bash
-Usage: check_pr [OPTIONS]
-
-Options:
-  --pr TEXT          Pull request to check  [required]
-  --host TEXT        Host to check  [required]
-  --owner TEXT       GitHub owner name  [default: gisce]
-  --repository TEXT  GitHub repository name  [default: erp]
-  --src TEXT         Remote src path  [default: /home/erp/src]
-  --help             Show this message and exit.
-```
-
-### STATUS PR
-
-```bash
-Usage: status_pr [OPTIONS]
+Usage: status [OPTIONS]
 
 Options:
   --deploy-id TEXT                Deploy id to mark
@@ -80,10 +65,10 @@ Options:
   --help                          Show this message and exit.
 ```
 
-### CHECK PRS STATUS
+### CHECK PRS
 
 ```bash
-Usage: check_prs_status [OPTIONS]
+Usage: check_prs [OPTIONS]
 
 Options:
   --prs TEXT         List of pull request separated by space (by default)
@@ -108,4 +93,18 @@ Options:
   --owner TEXT            GitHub owner name  [default: gisce]
   --repository TEXT       GitHub repository name  [default: erp]
   --help                  Show this message and exit.
+```
+
+### CHECK PR (deprecated)
+
+```bash
+Usage: check_pr [OPTIONS]
+
+Options:
+  --pr TEXT          Pull request to check  [required]
+  --host TEXT        Host to check  [required]
+  --owner TEXT       GitHub owner name  [default: gisce]
+  --repository TEXT  GitHub repository name  [default: erp]
+  --src TEXT         Remote src path  [default: /home/erp/src]
+  --help             Show this message and exit.
 ```

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -45,7 +45,8 @@ def configure_logging():
 
 @click.group(name='tailor')
 def tailor(**kwargs):
-    pass
+    from apply_pr.version import check_version
+    check_version()
 
 
 @tailor.command(name="apply_pr")
@@ -55,9 +56,6 @@ def apply_pr(
         owner, repository, src
 ):
     """Deploy a PR into a remote server via Fabric"""
-    from apply_pr.version import check_version
-    check_version()
-
     from apply_pr import fabfile
 
     url = urlparse(host)

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -49,15 +49,30 @@ def tailor(**kwargs):
     check_version()
 
 
-@tailor.command(name="apply_pr")
-@add_options(apply_pr_options)
 def apply_pr(
-        pr, host, from_number, from_commit, force_hostname,
-        owner, repository, src
+    pr, host, from_number, from_commit, force_hostname,
+    owner, repository, src
 ):
-    """Deploy a PR into a remote server via Fabric"""
+    """
+    Deploy a PR into a remote server via Fabric
+    :param pr:              Number of the PR to deploy
+    :type pr:               str
+    :param host:            Host to connect
+    :type host:             str
+    :param from_number:     Number of the commit to deploy from
+    :type from_number:      str
+    :param from_commit:     Hash of the commit to deploy from
+    :type from_commit:      str
+    :param force_hostname:  Hostname used in GitHub
+    :type force_hostname:   str
+    :param owner:           Owner of the repository of GitHub
+    :type owner:            str
+    :param repository:      Name of the repository of GitHub
+    :type repository:       str
+    :param src:             Source path to the repository directory
+    :type src:              str
+    """
     from apply_pr import fabfile
-
     url = urlparse(host)
     env.user = url.username
     env.password = url.password
@@ -70,6 +85,13 @@ def apply_pr(
         src=src, owner=owner, repository=repository,
         host=url.hostname
     )
+
+
+@tailor.command(name="deploy")
+@add_options(apply_pr_options)
+def deploy(**kwargs):
+    """Deploy a PR into a remote server via Fabric"""
+    return apply_pr(**kwargs)
 
 
 @tailor.command(name='check_pr')
@@ -97,11 +119,6 @@ def check_pr(pr, force, src, owner, repository, host):
             src=src, owner=owner, repository=repository, host=url.hostname)
 
 
-@tailor.command(name='status_pr')
-@click.option('--deploy-id', help='Deploy id to mark')
-@click.option('--status', type=click.Choice(['success', 'error', 'failure']),
-              help='Status to set', default='success', show_default=True)
-@add_options(github_options)
 def status_pr(deploy_id, status, owner, repository):
     """Update the status of a deploy into GitHub"""
     from apply_pr import fabfile
@@ -113,15 +130,16 @@ def status_pr(deploy_id, status, owner, repository):
             owner=owner, repository=repository)
 
 
-@tailor.command(name='check_prs_status')
-@click.option('--prs', required=True,
-              help='List of pull request separated by space (by default)')
-@click.option('--separator',
-              help='Character separator of list by default is space',
-              default=' ', required=True, show_default=True)
-@click.option('--version',
-              help="Compare with milestone and show if included in prs")
+@tailor.command(name='status')
+@click.option('--deploy-id', help='Deploy id to mark')
+@click.option('--status', type=click.Choice(['success', 'error', 'failure']),
+              help='Status to set', default='success', show_default=True)
 @add_options(github_options)
+def status(**kwargs):
+    """Update the status of a deploy into GitHub"""
+    status_pr(**kwargs)
+
+
 def check_prs_status(prs, separator, version, owner, repository):
     """Check the status of the PRs for a set of PRs"""
     from apply_pr import fabfile
@@ -135,6 +153,20 @@ def check_prs_status(prs, separator, version, owner, repository):
             repository=repository,
             separator=separator,
             version=version)
+
+
+@tailor.command(name='check_prs')
+@click.option('--prs', required=True,
+              help='List of pull request separated by space (by default)')
+@click.option('--separator',
+              help='Character separator of list by default is space',
+              default=' ', required=True, show_default=True)
+@click.option('--version',
+              help="Compare with milestone and show if included in prs")
+@add_options(github_options)
+def check_prs(**kwargs):
+    """Check the status of the PRs for a set of PRs"""
+    check_prs_status(**kwargs)
 
 
 @tailor.command(name='create_changelog')

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -27,6 +27,7 @@ apply_pr_options = deployment_options + [
     click.option("--force-hostname", help="Force hostname",  default=False)
 ]
 
+
 def add_options(options):
     def _add_options(func):
         for option in reversed(options):
@@ -42,9 +43,9 @@ def configure_logging():
     logging.basicConfig(level=log_level)
 
 
-@click.command(name="sastre")
+@click.command(name="apply_pr")
 @add_options(apply_pr_options)
-def sastre(
+def apply_pr(
         pr, host, from_number, from_commit, force_hostname,
         owner, repository, src
 ):
@@ -65,22 +66,6 @@ def sastre(
         src=src, owner=owner, repository=repository,
         host=url.hostname
     )
-
-@click.command()
-@add_options(apply_pr_options)
-def tailor(**kwargs):
-    sastre()
-
-@click.command()
-@add_options(apply_pr_options)
-def apply_pr(**kwargs):
-    """You can apply patches using 'sastre' or 'tailor'.\n
-    Use 'sastre --help' or 'tailor --help' for more information."""
-    print(colors.yellow(
-        "You can apply patches using 'sastre' or 'tailor'.\n"
-        "Use 'sastre --help' or 'tailor --help' for more information."
-    ))
-    sastre()
 
 
 @click.command(name='check_pr')
@@ -160,5 +145,10 @@ def create_changelog(milestone, issues, changelog_path, owner, repository):
             repository=repository)
 
 
+@click.command(name='tailor')
+@click.argument('command', default='help')
+def tailor(**kwargs):
+    print('mel')
+
 if __name__ == '__main__':
-    sastre()
+    tailor()

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -4,9 +4,35 @@ from urlparse import urlparse
 
 from fabric.tasks import execute, WrappedCallableTask
 from fabric.api import env
+from fabric import colors
 import click
 
 DEFAULT_LOG_LEVEL = 'ERROR'
+
+github_options = [
+    click.option('--owner', help='GitHub owner name', default='gisce', show_default=True),
+    click.option('--repository', help='GitHub repository name', default='erp', show_default=True),
+
+]
+
+deployment_options = github_options + [
+    click.option("--host", help="Host to apply", required=True),
+    click.option('--src', help='Remote src path',  default='/home/erp/src', show_default=True),
+]
+
+apply_pr_options = deployment_options + [
+    click.option("--pr", help="Pull request to apply", required=True),
+    click.option("--from-number", help="From commit number", default=0),
+    click.option("--from-commit", help="From commit hash (included)", default=None),
+    click.option("--force-hostname", help="Force hostname",  default=False)
+]
+
+def add_options(options):
+    def _add_options(func):
+        for option in reversed(options):
+            func = option(func)
+        return func
+    return _add_options
 
 
 def configure_logging():
@@ -16,21 +42,9 @@ def configure_logging():
     logging.basicConfig(level=log_level)
 
 
-@click.command(name="apply_pr")
-@click.option("--pr", help="Pull request to apply", required=True)
-@click.option("--host", help="Host to apply", required=True)
-@click.option("--from-number", help="From commit number", default=0)
-@click.option("--from-commit", help="From commit hash (included)",
-              default=None, show_default=True)
-@click.option("--force-hostname", help="Force hostname",
-              default=False, show_default=True)
-@click.option('--owner', help='GitHub owner name',
-              default='gisce', show_default=True)
-@click.option('--repository', help='GitHub repository name',
-              default='erp', show_default=True)
-@click.option('--src', help='Remote src path',
-              default='/home/erp/src', show_default=True)
-def apply_pr(
+@click.command(name="sastre")
+@add_options(apply_pr_options)
+def sastre(
         pr, host, from_number, from_commit, force_hostname,
         owner, repository, src
 ):
@@ -52,16 +66,26 @@ def apply_pr(
         host=url.hostname
     )
 
+@click.command()
+@add_options(apply_pr_options)
+def tailor(**kwargs):
+    sastre()
+
+@click.command()
+@add_options(apply_pr_options)
+def apply_pr(**kwargs):
+    """You can apply patches using 'sastre' or 'tailor'.\n
+    Use 'sastre --help' or 'tailor --help' for more information."""
+    print(colors.yellow(
+        "You can apply patches using 'sastre' or 'tailor'.\n"
+        "Use 'sastre --help' or 'tailor --help' for more information."
+    ))
+    sastre()
+
 
 @click.command(name='check_pr')
 @click.option('--pr', help='Pull request to check', required=True)
-@click.option('--host', help='Host to check', required=True)
-@click.option('--owner', help='GitHub owner name',
-              default='gisce', show_default=True)
-@click.option('--repository', help='GitHub repository name',
-              default='erp', show_default=True)
-@click.option('--src', help='Remote src path',
-              default='/home/erp/src', show_default=True)
+@add_options(deployment_options)
 def check_pr(pr, src, owner, repository, host):
     from apply_pr import fabfile
 
@@ -80,10 +104,7 @@ def check_pr(pr, src, owner, repository, host):
 @click.option('--deploy-id', help='Deploy id to mark')
 @click.option('--status', type=click.Choice(['success', 'error', 'failure']),
               help='Status to set', default='success', show_default=True)
-@click.option('--owner', help='GitHub owner name',
-              default='gisce', show_default=True)
-@click.option('--repository', help='GitHub repository name',
-              default='erp', show_default=True)
+@add_options(github_options)
 def status_pr(deploy_id, status, owner, repository):
     from apply_pr import fabfile
 
@@ -102,10 +123,7 @@ def status_pr(deploy_id, status, owner, repository):
               default=' ', required=True, show_default=True)
 @click.option('--version',
               help="Compare with milestone and show if included in prs")
-@click.option('--owner', help='GitHub owner name',
-              default='gisce', show_default=True)
-@click.option('--repository', help='GitHub repository name',
-              default='erp', show_default=True)
+@add_options(github_options)
 def check_prs_status(prs, separator, version, owner, repository):
     from apply_pr import fabfile
 
@@ -120,17 +138,14 @@ def check_prs_status(prs, separator, version, owner, repository):
             version=version)
 
 
-@click.command(name='check_prs_status')
+@click.command(name='create_changelog')
 @click.option('-m', '--milestone', required=True,
               help='Milestone to get the issues from (version)')
 @click.option('--issues/--no-issues', default=False, show_default=True,
               help='Also get the data on the issues')
 @click.option('--changelog_path', default='/tmp', show_default=True,
               help='Path to drop the changelog file in')
-@click.option('--owner', help='GitHub owner name',
-              default='gisce', show_default=True)
-@click.option('--repository', help='GitHub repository name',
-              default='erp', show_default=True)
+@add_options(github_options)
 def create_changelog(milestone, issues, changelog_path, owner, repository):
     from apply_pr import fabfile
 
@@ -146,4 +161,4 @@ def create_changelog(milestone, issues, changelog_path, owner, repository):
 
 
 if __name__ == '__main__':
-    apply_pr()
+    sastre()

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     description='Apply Pull Requests from GitHub',
     entry_points='''
         [console_scripts]
+        sastre=apply_pr.cli:sastre
+        tailor=apply_pr.cli:tailor
         apply_pr=apply_pr.cli:apply_pr
         check_pr=apply_pr.cli:check_pr
         status_pr=apply_pr.cli:status_pr

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='Apply Pull Requests from GitHub',
     entry_points='''
         [console_scripts]
-        sastre=apply_pr.cli:sastre
+        sastre=apply_pr.cli:tailor
         tailor=apply_pr.cli:tailor
         apply_pr=apply_pr.cli:apply_pr
         check_pr=apply_pr.cli:check_pr

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,6 @@ setup(
         [console_scripts]
         sastre=apply_pr.cli:tailor
         tailor=apply_pr.cli:tailor
-        apply_pr=apply_pr.cli:apply_pr
-        check_pr=apply_pr.cli:check_pr
-        status_pr=apply_pr.cli:status_pr
-        check_prs_status=apply_pr.cli:check_prs_status
-        create_changelog=apply_pr.cli:create_changelog
     ''',
     install_requires=[
         'fabric<2.0',


### PR DESCRIPTION
# Description

Allow to use `apply_pr` as `sastre` or `tailor`.

See `sastre --help` or `tailor --help`

```bash
$ sastre --help
Usage: sastre [OPTIONS]

Options:
  --owner TEXT           GitHub owner name  [default: gisce]
  --repository TEXT      GitHub repository name  [default: erp]
  --host TEXT            Host to apply  [required]
  --src TEXT             Remote src path  [default: /home/erp/src]
  --pr TEXT              Pull request to apply  [required]
  --from-number INTEGER  From commit number
  --from-commit TEXT     From commit hash (included)
  --force-hostname TEXT  Force hostname
  --help                 Show this message and exit.
```


# Development

- [x] Add console scripts for `sastre` and `tailor`
- [x] "_Deprecate_" apply_pr (show a warning message that you can use `sastre` and `tailor`)
- [x] Create a decorator to add command options (based on https://github.com/pallets/click/issues/108#issuecomment-255547347) and define common options for the different commands
- [x] Update README documentation
- [x] Update WIKI usage documentation