### PR TITLE
Replace Check PR with Get Deploys

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -53,27 +53,20 @@ def apply_pr(
     )
 
 
-@click.command(name='check_pr')
+@click.command(name='get_deploys')
 @click.option('--pr', help='Pull request to check', required=True)
-@click.option('--host', help='Host to check', required=True)
 @click.option('--owner', help='GitHub owner name',
               default='gisce', show_default=True)
 @click.option('--repository', help='GitHub repository name',
               default='erp', show_default=True)
-@click.option('--src', help='Remote src path',
-              default='/home/erp/src', show_default=True)
-def check_pr(pr, src, owner, repository, host):
+def get_deploys(pr, owner, repository):
     from apply_pr import fabfile
-
-    url = urlparse(host)
-    env.user = url.username
-    env.password = url.password
 
     configure_logging()
 
-    check_pr_task = WrappedCallableTask(fabfile.check_pr)
-    execute(check_pr_task, pr,
-            src=src, owner=owner, repository=repository, host=url.hostname)
+    get_deploys_task = WrappedCallableTask(fabfile.get_deploys)
+    execute(get_deploys_task, pr,
+            owner=owner, repository=repository)
 
 
 @click.command(name='status_pr')

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -362,9 +362,19 @@ def get_deploys(pr_number, owner='gisce', repository='erp'):
         print("Deployment id: {id} to {description}".format(**deployment))
         statusses = json.loads(requests.get(deployment['statuses_url'], headers=headers).text)
         for status in reversed(statusses):
-            print("  - {state} by {creator[login]} on {created_at}".format(
-                **status
-            ))
+            status_text = (
+                "  - {state} by {creator[login]} on {created_at}".format(
+                    **status
+                )
+            )
+            formatter = str
+            if status['state'] == 'pending':
+                formatter = colors.yellow
+            elif status['state'] in ['error', 'failure']:
+                formatter = colors.red
+            elif status['state'] == 'success':
+                formatter = colors.green
+            print(formatter(status_text))
 
 
 @task

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     entry_points='''
         [console_scripts]
         apply_pr=apply_pr.cli:apply_pr
-        check_pr=apply_pr.cli:check_pr
+        get_deploys=apply_pr.cli:get_deploys
         status_pr=apply_pr.cli:status_pr
         check_prs_status=apply_pr.cli:check_prs_status
         create_changelog=apply_pr.cli:create_changelog


### PR DESCRIPTION
Remove unused and wrong command `check_pr`.

- Check Pr used to check if the commits of a PR are applied
- It's not working properly and I think noone is using it. If so, the fabfile remains unchanged

ADD useful `get_deploys` command.

- Check for all deploy_ids of a PR
- Gets the user, the state and the date of the deploy update
- Filters by hosts

![selection_999 102](https://user-images.githubusercontent.com/19925414/42456573-8dcb5120-8395-11e8-882d-241c274d568b.png)

