### PR TITLE
IMP printed result for Check PRs subcommand

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -593,7 +593,7 @@ def prs_status(
             )
             tqdm.write(err_msg)
             ERRORS.append(err_msg)
-    for milestone in PRS.keys():
+    for milestone in sorted(PRS.keys()):
         print('\nMilestone {}'.format(milestone))
         for prmsg in PRS[milestone]:
             print('\t{}'.format(prmsg))


### PR DESCRIPTION
## PRE

The milestones of the PRs are sorted with using inorder tree sorting, which isn't user-friendly (from `dict.keys()`)

## POST 

The milestones for the PRs are sorted alphabetically (from `sorted(dict.keys())`)

- [x] ADD Sorted on check_prs milestone prints