### PR TITLE
ADD check for am session an instant before applying patches

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -520,6 +520,7 @@ def apply_pr(
         else:
             from_ = from_number
         tqdm.write(colors.yellow("Applying patches \U0001F648"))
+        check_am_session(src=src, repository=repository)
         apply_remote_patches(pr_number,
                              from_,
                              src=src,


### PR DESCRIPTION
## Description

>In [#66 ADD Check for git am sessions](https://github.com/gisce/apply_pr/pull/66) we added a check for current am session.

Checking for am sessions does not work for the following case:

_As the Download/Upload of patches may delay the am session start, if two users deploy the check may pass on both and after the "git am" they'll encounter the same failure as described in #66 ._

### Patch

- Add a check for am sessions just before applying the patches
- Do not remove the initial check (it'll be faster than downloading, uploading and then checking)

