### PR TITLE
ADD Port and Set default scheme (ssh) from Connection URI.

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -92,12 +92,11 @@ def apply_pr(
     env.password = url.password
 
     configure_logging()
-
     apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
     execute(
         apply_pr_task, pr, from_number, from_commit, hostname=force_hostname,
-        src=src, owner=owner, repository=repository,
-        host=url.hostname, sudo_user=sudo_user
+        src=src, owner=owner, repository=repository, sudo_user=sudo_user,
+        host='{}:{}'.format(url.hostname, (url.port or 22))
     )
 
 
@@ -129,8 +128,10 @@ def check_pr(pr, force, src, owner, repository, host):
     configure_logging()
 
     check_pr_task = WrappedCallableTask(fabfile.check_pr)
-    execute(check_pr_task, pr,
-            src=src, owner=owner, repository=repository, host=url.hostname)
+    execute(
+        check_pr_task, pr, src=src, owner=owner, repository=repository,
+        host='{}:{}'.format(url.hostname, (url.port or 22))
+    )
 
 
 def status_pr(deploy_id, status, owner, repository):

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -87,7 +87,7 @@ def apply_pr(
     :type sudo_user         str
     """
     from apply_pr import fabfile
-    url = urlparse(host)
+    url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password
 
@@ -121,7 +121,7 @@ def check_pr(pr, force, src, owner, repository, host):
         exit()
     from apply_pr import fabfile
 
-    url = urlparse(host)
+    url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -87,6 +87,8 @@ def apply_pr(
     :type sudo_user         str
     """
     from apply_pr import fabfile
+    if 'ssh' not in host and host[:2] != '//':
+        host = '//{}'.format(host)
     url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password


### PR DESCRIPTION
Connection port wasn't used so no connection could be established via non-standard port.
Following the standard of connections as explained [here](https://tools.ietf.org/id/draft-salowey-secsh-uri-00.html)

This improvement allows connections, allowing port usage like:

```
sastre deploy --host ssh://user@hostname.server:1234
```

As we are not using the connection method, we also used the default port for ssh (22) and added the default scheme for `ssh`. With this improvement, one can deploy like:

```
sastre deploy --host user@hostname.server
```