### PR TITLE
IMP Sastre usage

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -55,8 +55,8 @@ def deprecated(**kwargs):
     return apply_pr(**kwargs)
 
 
-@click.group(name='tailor')
-def tailor(**kwargs):
+@click.group(name='sastre')
+def sastre(**kwargs):
     from apply_pr.version import check_version
     check_version()
 
@@ -104,14 +104,14 @@ def apply_pr(
     return result
 
 
-@tailor.command(name="deploy")
+@sastre.command(name="deploy")
 @add_options(apply_pr_options)
 def deploy(**kwargs):
     """Deploy a PR into a remote server via Fabric"""
     return apply_pr(**kwargs)
 
 
-@tailor.command(name='check_pr')
+@sastre.command(name='check_pr')
 @click.option('--pr', help='Pull request to check', required=True)
 @click.option('--force/--no-force', default=False,
               help='Forces the usage of this command')
@@ -149,7 +149,7 @@ def status_pr(deploy_id, status, owner, repository):
             owner=owner, repository=repository)
 
 
-@tailor.command(name='status')
+@sastre.command(name='status')
 @click.argument('deploy-id')
 @click.argument('status', type=click.Choice(['success', 'error', 'failure']),
                 default='success')
@@ -174,7 +174,7 @@ def check_prs_status(prs, separator, version, owner, repository):
             version=version)
 
 
-@tailor.command(name='check_prs')
+@sastre.command(name='check_prs')
 @click.option('--prs', required=True,
               help='List of pull request separated by space (by default)')
 @click.option('--separator',
@@ -188,7 +188,7 @@ def check_prs(**kwargs):
     check_prs_status(**kwargs)
 
 
-@tailor.command(name='create_changelog')
+@sastre.command(name='create_changelog')
 @click.option('-m', '--milestone', required=True,
               help='Milestone to get the issues from (version)')
 @click.option('--issues/--no-issues', default=False, show_default=True,
@@ -221,7 +221,7 @@ def deploy_ids(pr, owner, repository):
             owner=owner, repository=repository)
 
 
-@tailor.command(name='get_deploys')
+@sastre.command(name='get_deploys')
 @click.argument('PR')
 @add_options(github_options)
 def get_deploys(**kwargs):
@@ -230,4 +230,4 @@ def get_deploys(**kwargs):
 
 
 if __name__ == '__main__':
-    tailor()
+    sastre()

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -222,13 +222,10 @@ def deploy_ids(pr, owner, repository):
 
 
 @tailor.command(name='get_deploys')
-@click.option('--pr', help='Pull request to check', required=True)
-@click.option('--owner', help='GitHub owner name',
-              default='gisce', show_default=True)
-@click.option('--repository', help='GitHub repository name',
-              default='erp', show_default=True)
+@click.argument('PR')
 @add_options(github_options)
 def get_deploys(**kwargs):
+    """Get deploy IDs and their status for a given PR number"""
     deploy_ids(**kwargs)
 
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -150,9 +150,9 @@ def status_pr(deploy_id, status, owner, repository):
 
 
 @tailor.command(name='status')
-@click.option('--deploy-id', help='Deploy id to mark')
-@click.option('--status', type=click.Choice(['success', 'error', 'failure']),
-              help='Status to set', default='success', show_default=True)
+@click.argument('deploy-id')
+@click.argument('status', type=click.Choice(['success', 'error', 'failure']),
+                default='success')
 @add_options(github_options)
 def status(**kwargs):
     """Update the status of a deploy into GitHub"""

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ setup(
     description='Apply Pull Requests from GitHub',
     entry_points='''
         [console_scripts]
-        sastre=apply_pr.cli:tailor
-        tailor=apply_pr.cli:tailor
+        sastre=apply_pr.cli:sastre
         apply_pr=apply_pr.cli:deprecated
     ''',
     install_requires=INSTALL_REQUIRES


### PR DESCRIPTION
### IMP Code

- Make all multiple options a combined list in top of the script as it was for the `apply_pr` command
- Replace "`tailor`" group to "`sastre`"

### Tailor

- DEL tailor command
- Now only `sastre` is available as it will be the final name of the command/package
- The `apply_pr` command is still available

### Status

- Now it uses arguments instead of options, being it's usage as `sastre status deploy-id status`
- Status argument defaults to "success" (the most common status used by this command), so it's not a required argument. Help continues to show the options.

### Get Deploys

- ~~Added a description to show on help~~ Done in https://github.com/gisce/apply_pr/pull/86
- The command now uses an argument instead of an option, being it's usage as `get_deploys pr`