### PR TITLE
Make "src" option to set the repository path

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -17,7 +17,7 @@ github_options = [
 
 deployment_options = github_options + [
     click.option("--host", help="Host to apply", required=True),
-    click.option('--src', help='Remote src path',  default='/home/erp/src', show_default=True),
+    click.option('--src', help='Remote repository src path',  default=False),
     click.option('--sudo_user', help='Sudo user from the host', default='erp', show_default=True),
 ]
 
@@ -63,7 +63,7 @@ def tailor(**kwargs):
 
 def apply_pr(
     pr, host, from_number=0, from_commit=None, force_hostname=False,
-    owner='gisce', repository='erp', src='/home/erp/src', sudo_user='erp',
+    owner='gisce', repository='erp', src=False, sudo_user='erp',
     auto_exit=False
 ):
     """


### PR DESCRIPTION
- UPD "src" opt to set the repository source path
  - Defaults to "/home/erp/src/{repository}"
  - Defaults to old behaviour
    - Old behaviour was to use it for the base path ("/home/erp/src") and then look for the directory with the name of the repository