### PR TITLE
Use packaging.version to compare versions

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -25,6 +25,7 @@ import StringIO
 from collections import OrderedDict
 
 from tqdm import tqdm
+from packaging import version as vsn
 
 
 logger = logging.getLogger(__name__)
@@ -646,7 +647,6 @@ def prs_status(
                 )
             )
             if version:
-                from packaging import version as vsn
                 if vsn.parse(milestone) <= vsn.parse(version):
                     if state_pr != 'closed':
                         message = colors.yellow(message)

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -646,7 +646,8 @@ def prs_status(
                 )
             )
             if version:
-                if milestone <= version:
+                from packaging import version as vsn
+                if vsn.parse(milestone) <= vsn.parse(version):
                     if state_pr != 'closed':
                         message = colors.yellow(message)
                         TO_APPLY.append(str(pr_number))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-slugify
 requests
 click
 tqdm
+packaging


### PR DESCRIPTION
Version and mileston were compared as strings, so "v2.99" was greater than "v2.100".
This PR uses packaging.version to parse and compare version tags.