### PR TITLE
Deploy PR on different repository folder name 

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -89,7 +89,7 @@ def sastre(**kwargs):
 def apply_pr(
     pr, host, from_number=0, from_commit=None, force_hostname=False,
     owner='gisce', repository='erp', src='/home/erp/src', sudo_user='erp',
-    auto_exit=False
+    auto_exit=False, force_name=None
 ):
     """
     Deploy a PR into a remote server via Fabric
@@ -124,7 +124,8 @@ def apply_pr(
     result = execute(
         apply_pr_task, pr, from_number, from_commit, hostname=force_hostname,
         src=src, owner=owner, repository=repository, sudo_user=sudo_user,
-        host='{}:{}'.format(url.hostname, (url.port or 22)), auto_exit=auto_exit
+        host='{}:{}'.format(url.hostname, (url.port or 22)), auto_exit=auto_exit,
+        force_name=force_name
     )
     return result
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -26,6 +26,9 @@ apply_pr_options = github_options + deployment_options + [
     click.option("--from-number", help="From commit number", default=0),
     click.option("--from-commit", help="From commit hash (included)", default=None),
     click.option("--force-hostname", help="Force hostname",  default=False),
+    click.option("--force-name", help="Force host repository name",  default=False),
+    click.option("--auto-exit", help="Execute git am --abort when fail",
+                 type=click.BOOL, default=False),
 ]
 
 status_options = github_options + [

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -503,12 +503,16 @@ def check_am_session(src='/home/erp/src', repository='erp', sudo_user='erp'):
 def apply_pr(
         pr_number, from_number=0, from_commit=None, skip_upload=False,
         hostname=False, src='/home/erp/src', owner='gisce', repository='erp',
-        sudo_user='erp', auto_exit=False
+        sudo_user='erp', auto_exit=False, force_name=None,
 ):
+    if force_name:
+        repository_name = force_name
+    else:
+        repository_name = repository
     try:
-        check_it_exists(src=src, repository=repository, sudo_user=sudo_user)
-        check_is_rolling(src=src, repository=repository, sudo_user=sudo_user)
-        check_am_session(src=src, repository=repository, sudo_user=sudo_user)
+        check_it_exists(src=src, repository=repository_name, sudo_user=sudo_user)
+        check_is_rolling(src=src, repository=repository_name, sudo_user=sudo_user)
+        check_am_session(src=src, repository=repository_name, sudo_user=sudo_user)
     except NetworkError as e:
         logger.error('Error connecting to specified host')
         logger.error(e)
@@ -538,19 +542,19 @@ def apply_pr(
             upload_patches(pr_number,
                            from_commit,
                            src=src,
-                           repository=repository,
+                           repository=repository_name,
                            sudo_user=sudo_user)
         if from_commit:
             from_ = from_commit
         else:
             from_ = from_number
         tqdm.write(colors.yellow("Applying patches \U0001F648"))
-        check_am_session(src=src, repository=repository)
+        check_am_session(src=src, repository=repository_name)
         result = apply_remote_patches(
             pr_number,
             from_,
             src=src,
-            repository=repository,
+            repository=repository_name,
             sudo_user=sudo_user,
             auto_exit=auto_exit,
         )


### PR DESCRIPTION
Enable two functions on console command `sastre deploy`
* **force-name**: Different repository folder name, _default None_
* **auto_exit**: Mark as error and do `git am --abort` when deploying PR has conflitcs, _default False_

```
sastre deploy --pr XXX --host=ssh://USER@HOST --force-name=erp_distri --auto-exit=True
```

![image](https://user-images.githubusercontent.com/4963636/67269973-01086d00-f4b8-11e9-99fa-5ef7ee71bba2.png)

closes #89 duplicate