### PR TITLE
Fix encoding on applying patch message

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -144,12 +144,12 @@ class GitApplier(object):
         self.catch_result(result)
 
     def catch_result(self, result):
-        for line in result.split('\n'):
+        for line in result.decode('utf-8').split('\n'):
             if re.match('Applying: ', line):
                 tqdm.write(colors.green(line))
                 self.pbar.update()
         if result.failed:
-            if "git config --global user.email" in result:
+            if "git config --global user.email" in result.decode('utf-8'):
                 logger.error(
                     "Need to configure git for this user\n"
                 )


### PR DESCRIPTION
This resolves two strings that need to be decoded from 'utf-8' when applying patch.