### PR TITLE
Fix 'get_deploys' function

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -478,7 +478,7 @@ def get_deploys(pr_number, owner='gisce', repository='erp', commit=None):
     pull = json.loads(r.text)
     if commit is None:
         commit = pull['head']['sha']
-    url = "https://api.github.com/repos/{}/{}/deployments?ref={}".format(
+    url = "https://api.github.com/repos/{}/{}/deployments?sha={}".format(
         owner, repository, commit
     )
     r = requests.get(url, headers=headers)


### PR DESCRIPTION
## Purpose

- Fix the function that retrieves and lists all deployments from a PR in a repository.
- URL now uses `sha` parameter instead of `ref`, avoiding `502` error on GItHub API requests.

## Additional info

- From https://docs.github.com/en/rest/reference/repos?query=Deployemt#list-deployment

![deployments](https://user-images.githubusercontent.com/49635897/138695041-41a75883-0144-419e-b208-536f95baacca.png)
