### PR TITLE
Try to fix CONFLICT on pop

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -186,6 +186,11 @@ class PatchApplier(object):
             if stash and stashed:
                 print(colors.yellow('Unstashing...'))
                 sudo("git stash pop")
+                error_on_pop = sudo("test -f .gitignore && git ls-files -om -X .gitignore || git ls-files -u")
+                if error_on_pop:
+                    sudo("git reset --merge")
+                    print(colors.red('\U000026D4 Error on stash pop. Keeping stash...'))
+                    raise
 
 
 class GitApplier(object):

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -180,6 +180,18 @@ class GitHubException(Exception):
 class PatchApplier(object):
 
     @staticmethod
+    def restore_stash():
+        with settings(warn_only=True):
+            pop_result = sudo("git stash pop")
+        unmerged_files = sudo("git ls-files -u")
+        if pop_result.failed or unmerged_files:
+            sudo("git reset --merge")
+            print(colors.red(
+                '\U000026D4 Error on stash pop. Keeping stash...'
+            ))
+            raise RuntimeError("Unable to restore stashed changes")
+
+    @staticmethod
     def apply(diff, stash=True, reject=False, message=None):
         need_stash = sudo("test -f .gitignore && git ls-files -om -X .gitignore || git ls-files -om")
         stashed = False
@@ -237,12 +249,7 @@ class PatchApplier(object):
         finally:
             if stash and stashed:
                 print(colors.yellow('Unstashing...'))
-                sudo("git stash pop")
-                error_on_pop = sudo("test -f .gitignore && git ls-files -om -X .gitignore || git ls-files -u")
-                if error_on_pop:
-                    sudo("git reset --merge")
-                    print(colors.red('\U000026D4 Error on stash pop. Keeping stash...'))
-                    raise
+                PatchApplier.restore_stash()
 
 
 class GitApplier(object):

--- a/tests/test_patch_applier.py
+++ b/tests/test_patch_applier.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+from contextlib import contextmanager
+
+from mock import Mock, call, patch
+
+from apply_pr.fabfile import PatchApplier
+
+
+class CommandResult(str):
+
+    def __new__(cls, value, failed=False):
+        result = str.__new__(cls, value)
+        result.failed = failed
+        return result
+
+
+@contextmanager
+def warn_only_settings(**kwargs):
+    assert kwargs == {'warn_only': True}
+    yield
+
+
+def test_restore_stash_accepts_successful_pop():
+    sudo = Mock(side_effect=[
+        CommandResult("Dropped refs/stash@{0}"),
+        CommandResult(""),
+    ])
+
+    with patch('apply_pr.fabfile.settings', warn_only_settings), \
+            patch('apply_pr.fabfile.sudo', sudo):
+        PatchApplier.restore_stash()
+
+    assert sudo.call_args_list == [
+        call("git stash pop"),
+        call("git ls-files -u"),
+    ]
+
+
+def test_restore_stash_resets_conflicting_pop_and_keeps_stash():
+    sudo = Mock(side_effect=[
+        CommandResult("CONFLICT", failed=True),
+        CommandResult("file.py"),
+        CommandResult(""),
+    ])
+
+    with patch('apply_pr.fabfile.settings', warn_only_settings), \
+            patch('apply_pr.fabfile.sudo', sudo):
+        try:
+            PatchApplier.restore_stash()
+        except RuntimeError as exc:
+            assert str(exc) == "Unable to restore stashed changes"
+        else:
+            raise AssertionError("A conflicting stash pop must fail")
+
+    assert sudo.call_args_list == [
+        call("git stash pop"),
+        call("git ls-files -u"),
+        call("git reset --merge"),
+    ]


### PR DESCRIPTION
- Restore dirty working-tree changes after applying a patch.
- Capture `git stash pop` failures without letting Fabric abort before cleanup.
- Detect unmerged index entries explicitly and reset a conflicting pop while preserving the stash.
- Keep compatibility with the current `PatchApplier.apply(..., sudo_user=...)` API.

## Validation

- Python 2.7: `pytest -q` — 17 passed.
