### PR TITLE
use sudo user to generate diff

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -55,8 +55,9 @@ def upload_diff(pr_number, src='/home/erp/src', repository='erp', sudo_user='erp
     remote_dir_bkp = '{}/{}/patches/{}/backup'.format(src, repository, pr_number)
     sudo("mkdir -p %s" % remote_dir)
     sudo("mkdir -p %s" % remote_dir_bkp)
+    sudo("chown -R {0}: {1}".format(sudo_user, remote_dir))
     with cd('{}/{}'.format(src, repository)):
-        sudo("git diff > {}/pre_{}.diff".format(remote_dir_bkp, pr_number))
+        sudo("git diff > {}/pre_{}.diff".format(remote_dir_bkp, pr_number), user=sudo_user)
     diff_path = '{}/{}.diff'.format(remote_dir, pr_number)
     with io.open('deploy/patches/{}.diff'.format(pr_number), 'r', encoding='utf-8') as dfile:
         logger.info('Uploading diff {}.diff'.format(pr_number))


### PR DESCRIPTION
When generate diff in some git versions not generate diff file:
![image](https://user-images.githubusercontent.com/4963636/170306972-71622052-4a12-446a-badf-4efd0363f5f8.png)

Change method passing user as sudo user to generate diff.