### PR TITLE
Allow pass url for pr number

### DIFF
--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -183,6 +183,9 @@ def apply_pr(
 @add_options(apply_pr_options)
 def deploy(**kwargs):
     """Deploy a PR into a remote server via Fabric"""
+    if not isinstance(kwargs['pr'], (list, tuple)):
+        from apply_pr.fabfile import get_info_from_url
+        kwargs.update(get_info_from_url(kwargs['pr']))
     return apply_pr(**kwargs)
 
 

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -49,6 +49,19 @@ if config.get('logging'):
 
 DEPLOYED = {'pro': 'deployed', 'pre': 'deployed PRE', 'test': 'deployed PRE'}
 
+
+def get_info_from_url(pr):
+    if pr.startswith('https://'):
+        vals = pr.split('/')
+        return {
+           'owner': vals[3],
+           'repository': vals[4],
+           'pr': vals[6]
+        }
+    else:
+        return {'pr': pr}
+
+
 @task
 def upload_diff(pr_number, src='/home/erp/src', repository='erp', sudo_user='erp'):
     temp_dir = '/tmp/%s.diff' % pr_number

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -53,11 +53,14 @@ DEPLOYED = {'pro': 'deployed', 'pre': 'deployed PRE', 'test': 'deployed PRE'}
 def get_info_from_url(pr):
     if pr.startswith('https://'):
         vals = pr.split('/')
-        return {
+        info = {
            'owner': vals[3],
            'repository': vals[4],
            'pr': vals[6]
         }
+        if len(vals) == 9 and vals[7] == 'commits':
+            info['from_commit'] = vals[8]
+        return info
     else:
         return {'pr': pr}
 


### PR DESCRIPTION
Now is possible to do:

```
sastre deploy --pr=https://github.com/gisce/erp/pull/15395 --host=user@somehost--environ=pro
```

And deploy from a commit using

```
sastre deploy --pr=https://github.com/gisce/erp/pull/15395/commits/aed98389b88c4bbd000d31118e392c4c1fd23d03 \
--host=user@somhost--environ=pro
```

And the pr_number, owner, repository will be extracted from the pull-request url