### PR TITLE
More explicit repository not found error message

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -659,7 +659,7 @@ def check_it_exists(src='/home/erp/src', repository='erp', sudo_user='erp'):
     with settings(hide('everything'), sudo_user=sudo_user, warn_only=True):
         res = sudo("ls {}/{}".format(src, repository))
         if res.return_code:
-            message = "The repository does not exist or cannot be found"
+            message = "The repository {} does not exist or cannot be found in {}".format(repository, src)
             tqdm.write(colors.red(message))
             abort(message)
 


### PR DESCRIPTION
Change the repository check error message so that it is more explicit. Useful when some implicit arguments such as `repository` or `src` should be changed, making the tool more verbal and accessible.

Before:
![image](https://github.com/gisce/apply_pr/assets/4147225/83331211-a193-4c4c-ad8c-bcfd4bf64673)

After:
![image](https://github.com/gisce/apply_pr/assets/4147225/7ec04bbd-22ec-4071-bf18-ce3406266dd1)