### PR TITLE
Fix comparing unicode to decoded text

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -284,7 +284,7 @@ class GitApplier(object):
                 tqdm.write(colors.green(line))
                 self.pbar.update()
         if result_failed:
-            if "git config --global user.email" in result:
+            if "git config --global user.email" in result_text:
                 logger.error(
                     "Need to configure git for this user\n"
                 )


### PR DESCRIPTION
Fix comparing an unicode text with a bytes string and when decoded an error is raised if is decoded with default encoding ('ascii')