### PR TITLE
Raise explicit errors on github token not provided or expired

### DIFF
--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -46,8 +46,25 @@ for k in output.keys():
     output[k] = False
 
 
+def is_github_token_valid(token):
+    headers = {'Authorization': 'token {token}'.format(token=token)}
+    url = "https://api.github.com/user"
+
+    r = requests.get(url, headers=headers)
+
+    return r.status_code == 200
+
+
 def github_config(**config):
-    return config_from_environment('GITHUB', ['token'], **config)
+    def validate(_config):
+        if 'token' not in _config or not _config['token']:
+            raise EnvironmentError("GITHUB_TOKEN variable not provided")
+        if not is_github_token_valid(_config['token']):
+            raise EnvironmentError("GITHUB_TOKEN not valid or expired")
+
+    res = config_from_environment('GITHUB', ['token'], **config)
+    validate(res)
+    return res
 
 
 def apply_pr_config(**config):


### PR DESCRIPTION
Raise explicit error mesage on any github token issue. Before it threw unexpected errors in the code,

![image](https://github.com/user-attachments/assets/d083864a-0294-4f6e-8ea4-97080c10c670)
