### PR TITLE
ci: fix invalid release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           generate_release_notes: true
       - run: rm -r dist
       - name: Publish a Python distribution to PyPI
-        if: ${{ contains(github.ref, '-rc') }} == false
+        if: ${{ !contains(github.ref, '-rc') }}
         env:
           PYPI_MASTER_TOKEN: ${{ secrets.PYPI_MASTER_TOKEN }}
           PYTHON_TOKEN: ${{ secrets.PYTHON_TOKEN }}


### PR DESCRIPTION
## Summary
- fix the GitHub Actions `if` expression in the PyPI publish step
- avoid the workflow syntax warning caused by literal text outside `${{ }}`

## Testing
- not run (GitHub Actions workflow syntax fix only)