### PR TITLE
ci: modernize release runner for Python 2 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,26 +8,21 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: python:2.7-slim
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 2.7
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
         run: |
-          sudo apt update
-          sudo apt install python2 python2-dev
-          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-          sudo python2 get-pip.py
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 2
-          printf '1\n' | sudo update-alternatives --config python
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-        with:
-          strip_v: false
+          apt-get update
+          apt-get install -y --no-install-recommends binutils
+          rm -rf /var/lib/apt/lists/*
+      - name: Install Python build dependencies
+        run: |
+          python -m pip install --upgrade "pip<21" "setuptools<45" "wheel<0.35" "twine<2" "virtualenv<20.22" "pyinstaller==3.3.1"
       - name: Generate binary
         run: |
-          pip install pyinstaller==3.3.1
           pip install -e .
           pyinstaller --onefile -n sastre apply_pr/cli.py
       - name: Creating a realease/pre-release
@@ -37,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: dist/sastre
-          tag_name: ${{steps.tag.outputs.tag}}
+          tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') }}
           generate_release_notes: true
@@ -54,9 +49,5 @@ jobs:
             exit 0
           fi
           echo "::add-mask::${PYPI_TOKEN}"
-          python -m pip install --upgrade pip setuptools wheel twine virtualenv
-          python -m virtualenv venv
-          . venv/bin/activate
-          pip install --upgrade pip setuptools wheel
           python setup.py sdist bdist_wheel
           twine upload --non-interactive -u __token__ -p "${PYPI_TOKEN}" dist/*


### PR DESCRIPTION
## Summary

- replace the deprecated/blocked `ubuntu-20.04` runner label with a modern GitHub-hosted runner
- run the release job inside `python:2.7-slim` instead of bootstrapping Python 2 manually with apt + get-pip
- pin Python packaging/build tools to Python 2 compatible versions
- simplify tag resolution by using `${{ github.ref_name }}`

## Why

The current release workflow is getting stuck queued while requesting:

- `runs-on: ubuntu-20.04`

This change keeps a modern host runner while preserving a Python 2.7 runtime for the binary build and PyPI publish steps.

## Main changes

- `runs-on: ubuntu-latest`
- `container: python:2.7-slim`
- remove manual Python 2 bootstrap
- install `binutils` in the container for PyInstaller
- pin `pip`, `setuptools`, `wheel`, `twine`, `virtualenv` and `pyinstaller` to Python 2 compatible ranges
- replace `dawidd6/action-get-tag` with `github.ref_name`

## Notes

- intent is to preserve the current Python 2 based release flow while using a currently available GitHub runner
- this PR does not change application code, only the release workflow

## Testing

- not run locally (GitHub Actions workflow change only)
