### PR TITLE
ci: restore binutils for PyInstaller build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,15 @@ jobs:
       image: python:2.7-slim
     steps:
       - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          cat > /etc/apt/sources.list <<'EOF'
+          deb http://archive.debian.org/debian buster main
+          deb http://archive.debian.org/debian-security buster/updates main
+          EOF
+          printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99no-check-valid
+          apt-get update
+          apt-get install -y --no-install-recommends binutils
       - name: Install Python build dependencies
         run: |
           python -m pip install --upgrade "pip<21" "setuptools<45" "wheel<0.35" "twine<2" "virtualenv<20.22" "pyinstaller==3.3.1"


### PR DESCRIPTION
## Summary

- restore the minimal system dependency required by PyInstaller inside the Python 2.7 container
- point apt to `archive.debian.org` because the `python:2.7-slim` image is based on Debian buster EOL

## Why

The current release workflow already uses:
- `runs-on: ubuntu-latest`
- `container: python:2.7-slim`

But the build still fails in the `Generate binary` step because PyInstaller needs system tooling from `binutils`.

This PR adds back only that minimal dependency and the archive workaround required to install it.

## Testing

- not run locally (GitHub Actions workflow change only)
