### PR TITLE
ci: remove unsupported twine flag on Python 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           fi
           echo "::add-mask::${PYPI_TOKEN}"
           python setup.py sdist bdist_wheel
-          twine upload --non-interactive -u __token__ -p "${PYPI_TOKEN}" dist/*
+          twine upload -u __token__ -p "${PYPI_TOKEN}" dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,12 @@ jobs:
       - name: Publish a Python distribution to PyPI
         if: ${{ !contains(github.ref, '-rc') }}
         env:
-          PYPI_MASTER_TOKEN: ${{ secrets.PYPI_MASTER_TOKEN }}
-          PYTHON_TOKEN: ${{ secrets.PYTHON_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_MASTER_TOKEN }}
         run: |
-          export PYPI_TOKEN="${PYPI_MASTER_TOKEN:-${PYTHON_TOKEN:-}}"
-          if [ -z "${PYPI_TOKEN}" ]; then
-            echo "No PYPI_MASTER_TOKEN or PYTHON_TOKEN configured; skipping PyPI publish"
+          if [ -z "$TWINE_PASSWORD" ]; then
+            echo "PYPI_MASTER_TOKEN not configured; skipping PyPI publish"
             exit 0
           fi
-          echo "::add-mask::${PYPI_TOKEN}"
           python setup.py sdist bdist_wheel
-          twine upload -u __token__ -p "${PYPI_TOKEN}" dist/*
+          python -m twine upload dist/*


### PR DESCRIPTION
## Summary

- remove `--non-interactive` from `twine upload`

## Why

The current release workflow already completes:
- runner startup
- Python 2 container setup
- PyInstaller binary build
- GitHub release creation

It now fails only in the PyPI publish step because the pinned Python 2 compatible `twine<2` does not support the `--non-interactive` flag.

This PR keeps the Python 2 compatible toolchain and switches the upload command to a syntax supported by that `twine` version.

## Testing

- not run locally (GitHub Actions workflow change only)
