### PR TITLE
Corregir UnicodeEncodeError en OAuth Python 3

### DIFF
--- a/apply_pr/github_utils.py
+++ b/apply_pr/github_utils.py
@@ -97,6 +97,6 @@ def oauth_login():
         user_info = requests.get("https://api.github.com/user", headers=headers)
         user_data = user_info.json()
         print(
-            "\n\ud83d\udc4b Welcome, {}!".format(
+            "\n\U0001f44b Welcome, {}!".format(
                 user_data['login']))
     return token

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import io
+import sys
+import types
+import unittest
+
+
+class DummyQRCode(object):
+    def add_data(self, data):
+        pass
+
+    def make(self):
+        pass
+
+    def print_ascii(self, invert=True):
+        pass
+
+
+fake_qrcode = types.ModuleType(str('qrcode'))
+fake_qrcode.QRCode = DummyQRCode
+sys.modules.setdefault('qrcode', fake_qrcode)
+
+fake_osconf = types.ModuleType(str('osconf'))
+fake_osconf.config_from_environment = lambda prefix, **config: config
+sys.modules.setdefault('osconf', fake_osconf)
+
+fake_importlib_metadata = types.ModuleType(str('importlib_metadata'))
+fake_importlib_metadata.version = lambda package: 'unknown'
+sys.modules.setdefault('importlib_metadata', fake_importlib_metadata)
+
+import apply_pr.github_utils as github_utils
+
+
+class DummyResponse(object):
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+class OAuthLoginEncodingTest(unittest.TestCase):
+    def test_success_message_uses_valid_unicode_codepoints(self):
+        calls = []
+
+        def fake_post(url, data=None, headers=None):
+            calls.append(url)
+            if url.endswith('/device/code'):
+                return DummyResponse({
+                    'user_code': 'ABCD-1234',
+                    'verification_uri': 'https://github.com/login/device',
+                    'device_code': 'device-code',
+                    'interval': 0,
+                })
+            return DummyResponse({'access_token': 'token-value'})
+
+        def fake_get(url, headers=None):
+            return DummyResponse({'login': 'ecarreras'})
+
+        old_post = github_utils.requests.post
+        old_get = github_utils.requests.get
+        old_qrcode = github_utils.qrcode.QRCode
+        old_sleep = github_utils.time.sleep
+        old_stdout = sys.stdout
+        output = io.StringIO()
+        try:
+            github_utils.requests.post = fake_post
+            github_utils.requests.get = fake_get
+            github_utils.qrcode.QRCode = DummyQRCode
+            github_utils.time.sleep = lambda interval: None
+            sys.stdout = output
+
+            token = github_utils.oauth_login()
+        finally:
+            github_utils.requests.post = old_post
+            github_utils.requests.get = old_get
+            github_utils.qrcode.QRCode = old_qrcode
+            github_utils.time.sleep = old_sleep
+            sys.stdout = old_stdout
+
+        self.assertEqual(token, 'token-value')
+        text = output.getvalue()
+        self.assertIn('Welcome, ecarreras!', text)
+        text.encode('utf-8')
+        self.assertNotIn('\ud83d', text)
+        self.assertNotIn('\udc4b', text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Objectiu

- Corregir l'error `UnicodeEncodeError: surrogates not allowed` durant el flux OAuth de Python 3.

## Causa

El missatge de benvinguda feia servir una parella surrogate (`\ud83d\udc4b`) per imprimir l'emoji 👋. En Python 3 això pot construir una cadena Unicode invàlida per codificar a UTF-8.

## Canvi

- Substituïda la parella surrogate per un code point Unicode complet: `\U0001f44b`.
- Afegit test unitari del flux OAuth mockejat per assegurar que el missatge es pot codificar en UTF-8 i no conté surrogates.

## Validació

- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile apply_pr/github_utils.py tests/test_github_utils.py`
- Python 2.7 `py_compile` dels mateixos fitxers
- Python 2.7 `unittest discover -s tests -v`

## Relacionat

- Refs #168
