### PR TITLE
Permetre claus SSH específiques

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ API](https://developer.github.com/v3/repos/deployments/) from GitHub.
 To use you must [generate an OAuth token](https://github.com/settings/tokens/new)
 from GitHub and set to the `GITHUB_TOKEN` environment variable.
 
+SSH connections use the standard `~/.ssh/config` file. If the private key must
+be provided through the environment, set `SSH_PRIVATE_KEY` with the PEM key
+contents before running the command.
+
 ## Command line scripts
 
 This repository uses the [Click](http://click.pocoo.org/5/) package to

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ To use you must [generate an OAuth token](https://github.com/settings/tokens/new
 from GitHub and set to the `GITHUB_TOKEN` environment variable.
 
 SSH connections use the standard `~/.ssh/config` file. If the private key must
-be provided explicitly, set `SSH_PRIVATE_KEY_FILE` with the key file path or
-`SSH_PRIVATE_KEY` with the PEM key contents before running the command.
+be provided explicitly, set `APPLY_PR_SSH_KEY_PATH` with the key file path
+before running the command.
 
 ## Command line scripts
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ To use you must [generate an OAuth token](https://github.com/settings/tokens/new
 from GitHub and set to the `GITHUB_TOKEN` environment variable.
 
 SSH connections use the standard `~/.ssh/config` file. If the private key must
-be provided through the environment, set `SSH_PRIVATE_KEY` with the PEM key
-contents before running the command.
+be provided explicitly, set `SSH_PRIVATE_KEY_FILE` with the key file path or
+`SSH_PRIVATE_KEY` with the PEM key contents before running the command.
 
 ## Command line scripts
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -1,6 +1,9 @@
 import logging
 import os
 import sys
+import atexit
+import stat
+import tempfile
 import six
 if six.PY2:
     from urlparse import urlparse
@@ -13,6 +16,7 @@ from fabric import colors
 import click
 
 DEFAULT_LOG_LEVEL = 'ERROR'
+_SSH_PRIVATE_KEY_FILE = None
 
 github_options = [
     click.option('--owner', help='GitHub owner name', default='gisce', show_default=True),
@@ -93,6 +97,35 @@ def configure_logging():
     logging.basicConfig(level=log_level)
 
 
+def cleanup_ssh_private_key_file():
+    global _SSH_PRIVATE_KEY_FILE
+    if _SSH_PRIVATE_KEY_FILE and os.path.exists(_SSH_PRIVATE_KEY_FILE):
+        os.unlink(_SSH_PRIVATE_KEY_FILE)
+    _SSH_PRIVATE_KEY_FILE = None
+
+
+def configure_ssh_auth():
+    global _SSH_PRIVATE_KEY_FILE
+    env.use_ssh_config = True
+    private_key = os.environ.get('SSH_PRIVATE_KEY')
+    if not private_key:
+        return
+    cleanup_ssh_private_key_file()
+    fd, key_filename = tempfile.mkstemp(prefix='apply_pr_ssh_', suffix='.key')
+    try:
+        if not private_key.endswith('\n'):
+            private_key += '\n'
+        if six.PY3:
+            private_key = private_key.encode('utf-8')
+        os.write(fd, private_key)
+    finally:
+        os.close(fd)
+    os.chmod(key_filename, stat.S_IRUSR | stat.S_IWUSR)
+    env.key_filename = key_filename
+    _SSH_PRIVATE_KEY_FILE = key_filename
+    atexit.register(cleanup_ssh_private_key_file)
+
+
 @click.command('apply_pr')
 @add_options(apply_pr_options)
 def deprecated(**kwargs):
@@ -151,6 +184,7 @@ def apply_pr(
     url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password
+    configure_ssh_auth()
     if not prs and not pr:
         click.echo(colors.red(
             u"\U000026D4 ERROR: You can't deploy nothing without indicate PR"
@@ -218,6 +252,7 @@ def check_pr(pr, force, src, owner, repository, host):
     url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password
+    configure_ssh_auth()
 
     configure_logging()
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -1,9 +1,6 @@
 import logging
 import os
 import sys
-import atexit
-import stat
-import tempfile
 import six
 if six.PY2:
     from urlparse import urlparse
@@ -16,7 +13,6 @@ from fabric import colors
 import click
 
 DEFAULT_LOG_LEVEL = 'ERROR'
-_SSH_PRIVATE_KEY_FILE = None
 
 github_options = [
     click.option('--owner', help='GitHub owner name', default='gisce', show_default=True),
@@ -97,38 +93,11 @@ def configure_logging():
     logging.basicConfig(level=log_level)
 
 
-def cleanup_ssh_private_key_file():
-    global _SSH_PRIVATE_KEY_FILE
-    if _SSH_PRIVATE_KEY_FILE and os.path.exists(_SSH_PRIVATE_KEY_FILE):
-        os.unlink(_SSH_PRIVATE_KEY_FILE)
-    _SSH_PRIVATE_KEY_FILE = None
-
-
 def configure_ssh_auth():
-    global _SSH_PRIVATE_KEY_FILE
     env.use_ssh_config = True
-    private_key_file = os.environ.get('SSH_PRIVATE_KEY_FILE')
-    if private_key_file:
-        cleanup_ssh_private_key_file()
-        env.key_filename = private_key_file
-        return
-    private_key = os.environ.get('SSH_PRIVATE_KEY')
-    if not private_key:
-        return
-    cleanup_ssh_private_key_file()
-    fd, key_filename = tempfile.mkstemp(prefix='apply_pr_ssh_', suffix='.key')
-    try:
-        if not private_key.endswith('\n'):
-            private_key += '\n'
-        if six.PY3:
-            private_key = private_key.encode('utf-8')
-        os.write(fd, private_key)
-    finally:
-        os.close(fd)
-    os.chmod(key_filename, stat.S_IRUSR | stat.S_IWUSR)
-    env.key_filename = key_filename
-    _SSH_PRIVATE_KEY_FILE = key_filename
-    atexit.register(cleanup_ssh_private_key_file)
+    ssh_key_path = os.environ.get('APPLY_PR_SSH_KEY_PATH')
+    if ssh_key_path:
+        env.key_filename = ssh_key_path
 
 
 @click.command('apply_pr')

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -107,6 +107,11 @@ def cleanup_ssh_private_key_file():
 def configure_ssh_auth():
     global _SSH_PRIVATE_KEY_FILE
     env.use_ssh_config = True
+    private_key_file = os.environ.get('SSH_PRIVATE_KEY_FILE')
+    if private_key_file:
+        cleanup_ssh_private_key_file()
+        env.key_filename = private_key_file
+        return
     private_key = os.environ.get('SSH_PRIVATE_KEY')
     if not private_key:
         return

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import stat
 import sys
 import types
 import unittest
@@ -39,15 +38,11 @@ import apply_pr.cli as cli
 
 class ConfigureSSHAuthTest(unittest.TestCase):
     def setUp(self):
-        os.environ.pop('SSH_PRIVATE_KEY', None)
-        os.environ.pop('SSH_PRIVATE_KEY_FILE', None)
-        cli.cleanup_ssh_private_key_file()
+        os.environ.pop('APPLY_PR_SSH_KEY_PATH', None)
         fake_env.__dict__.clear()
 
     def tearDown(self):
-        os.environ.pop('SSH_PRIVATE_KEY', None)
-        os.environ.pop('SSH_PRIVATE_KEY_FILE', None)
-        cli.cleanup_ssh_private_key_file()
+        os.environ.pop('APPLY_PR_SSH_KEY_PATH', None)
         fake_env.__dict__.clear()
 
     def test_enables_ssh_config_without_private_key(self):
@@ -56,32 +51,13 @@ class ConfigureSSHAuthTest(unittest.TestCase):
         self.assertTrue(fake_env.use_ssh_config)
         self.assertFalse(hasattr(fake_env, 'key_filename'))
 
-    def test_uses_ssh_private_key_file_when_configured(self):
-        os.environ['SSH_PRIVATE_KEY_FILE'] = '/tmp/sastre_id_rsa'
+    def test_uses_apply_pr_ssh_key_path_when_configured(self):
+        os.environ['APPLY_PR_SSH_KEY_PATH'] = '/tmp/sastre_id_rsa'
 
         cli.configure_ssh_auth()
 
         self.assertTrue(fake_env.use_ssh_config)
         self.assertEqual(fake_env.key_filename, '/tmp/sastre_id_rsa')
-
-    def test_writes_ssh_private_key_to_restricted_temp_file(self):
-        os.environ['SSH_PRIVATE_KEY'] = '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----'
-
-        cli.configure_ssh_auth()
-
-        key_filename = fake_env.key_filename
-        self.assertTrue(os.path.exists(key_filename))
-        file_mode = stat.S_IMODE(os.stat(key_filename).st_mode)
-        self.assertEqual(file_mode, stat.S_IRUSR | stat.S_IWUSR)
-        with open(key_filename, 'rb') as key_file:
-            key_contents = key_file.read()
-        self.assertEqual(
-            key_contents,
-            b'-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----\n'
-        )
-
-        cli.cleanup_ssh_private_key_file()
-        self.assertFalse(os.path.exists(key_filename))
 
 
 if __name__ == '__main__':

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -40,11 +40,13 @@ import apply_pr.cli as cli
 class ConfigureSSHAuthTest(unittest.TestCase):
     def setUp(self):
         os.environ.pop('SSH_PRIVATE_KEY', None)
+        os.environ.pop('SSH_PRIVATE_KEY_FILE', None)
         cli.cleanup_ssh_private_key_file()
         fake_env.__dict__.clear()
 
     def tearDown(self):
         os.environ.pop('SSH_PRIVATE_KEY', None)
+        os.environ.pop('SSH_PRIVATE_KEY_FILE', None)
         cli.cleanup_ssh_private_key_file()
         fake_env.__dict__.clear()
 
@@ -53,6 +55,14 @@ class ConfigureSSHAuthTest(unittest.TestCase):
 
         self.assertTrue(fake_env.use_ssh_config)
         self.assertFalse(hasattr(fake_env, 'key_filename'))
+
+    def test_uses_ssh_private_key_file_when_configured(self):
+        os.environ['SSH_PRIVATE_KEY_FILE'] = '/tmp/sastre_id_rsa'
+
+        cli.configure_ssh_auth()
+
+        self.assertTrue(fake_env.use_ssh_config)
+        self.assertEqual(fake_env.key_filename, '/tmp/sastre_id_rsa')
 
     def test_writes_ssh_private_key_to_restricted_temp_file(self):
         os.environ['SSH_PRIVATE_KEY'] = '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----'

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -25,6 +25,9 @@ fake_fabric_api.env = fake_env
 fake_fabric_colors.red = lambda text: text
 fake_fabric_colors.yellow = lambda text: text
 fake_fabric_colors.green = lambda text: text
+fake_fabric.tasks = fake_fabric_tasks
+fake_fabric.api = fake_fabric_api
+fake_fabric.colors = fake_fabric_colors
 
 sys.modules.setdefault('fabric', fake_fabric)
 sys.modules.setdefault('fabric.tasks', fake_fabric_tasks)

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import os
+import stat
+import sys
+import types
+import unittest
+
+
+class DummyEnv(object):
+    pass
+
+
+fake_env = DummyEnv()
+
+fake_fabric = types.ModuleType(str('fabric'))
+fake_fabric_tasks = types.ModuleType(str('fabric.tasks'))
+fake_fabric_api = types.ModuleType(str('fabric.api'))
+fake_fabric_colors = types.ModuleType(str('fabric.colors'))
+
+fake_fabric_tasks.execute = lambda *args, **kwargs: {}
+fake_fabric_tasks.WrappedCallableTask = lambda task: task
+fake_fabric_api.env = fake_env
+fake_fabric_colors.red = lambda text: text
+fake_fabric_colors.yellow = lambda text: text
+fake_fabric_colors.green = lambda text: text
+
+sys.modules.setdefault('fabric', fake_fabric)
+sys.modules.setdefault('fabric.tasks', fake_fabric_tasks)
+sys.modules.setdefault('fabric.api', fake_fabric_api)
+sys.modules.setdefault('fabric.colors', fake_fabric_colors)
+
+import apply_pr.cli as cli
+
+
+class ConfigureSSHAuthTest(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop('SSH_PRIVATE_KEY', None)
+        cli.cleanup_ssh_private_key_file()
+        fake_env.__dict__.clear()
+
+    def tearDown(self):
+        os.environ.pop('SSH_PRIVATE_KEY', None)
+        cli.cleanup_ssh_private_key_file()
+        fake_env.__dict__.clear()
+
+    def test_enables_ssh_config_without_private_key(self):
+        cli.configure_ssh_auth()
+
+        self.assertTrue(fake_env.use_ssh_config)
+        self.assertFalse(hasattr(fake_env, 'key_filename'))
+
+    def test_writes_ssh_private_key_to_restricted_temp_file(self):
+        os.environ['SSH_PRIVATE_KEY'] = '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----'
+
+        cli.configure_ssh_auth()
+
+        key_filename = fake_env.key_filename
+        self.assertTrue(os.path.exists(key_filename))
+        file_mode = stat.S_IMODE(os.stat(key_filename).st_mode)
+        self.assertEqual(file_mode, stat.S_IRUSR | stat.S_IWUSR)
+        with open(key_filename, 'rb') as key_file:
+            key_contents = key_file.read()
+        self.assertEqual(
+            key_contents,
+            b'-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----\n'
+        )
+
+        cli.cleanup_ssh_private_key_file()
+        self.assertFalse(os.path.exists(key_filename))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Resum

- Activa l'ús de `~/.ssh/config` en connexions Fabric.
- Permet definir `APPLY_PR_SSH_KEY_PATH` amb la ruta d'una clau privada existent.
- Assigna aquesta ruta directament a `env.key_filename`, sense crear fitxers temporals ni acceptar contingut PEM per entorn.
- Documenta el comportament al README.

## Tests

```bash
python3 -m unittest discover -s tests -p 'test*.py' -v
/home/openclaw/.pyenv/versions/erp2/bin/python -m unittest discover -s tests -p 'test*.py' -v
```

Refs #170