### PR TITLE
Add SSH proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ from GitHub and set to the `GITHUB_TOKEN` environment variable.
 
 SSH connections use the standard `~/.ssh/config` file. If the private key must
 be provided explicitly, set `APPLY_PR_SSH_KEY_PATH` with the key file path
-before running the command.
+before running the command. When the target host requires a jump server, pass
+`--proxy user@proxy-host`, equivalent to using `ssh -J user@proxy-host`.
 
 ## Command line scripts
 
@@ -46,6 +47,7 @@ Usage: deploy [OPTIONS]
 Options:
   --pr TEXT              Pull request to deploy  [required]
   --host TEXT            Host to where to be deployed  [required]
+  --proxy TEXT           SSH proxy/jump host
   --from-number INTEGER  From commit number
   --from-commit TEXT     From commit hash (included)
   --force-hostname TEXT  Force hostname  [default: False]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Usage: check_pr [OPTIONS]
 Options:
   --pr TEXT          Pull request to check  [required]
   --host TEXT        Host to check  [required]
+  --proxy TEXT       SSH proxy/jump host
   --owner TEXT       GitHub owner name  [default: gisce]
   --repository TEXT  GitHub repository name  [default: erp]
   --src TEXT         Remote src path  [default: /home/erp/src]

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -22,6 +22,7 @@ github_options = [
 
 deployment_options = [
     click.option("--host", help="Host to apply", required=True),
+    click.option('--proxy', help='SSH proxy/jump host'),
     click.option('--src', help='Remote src path',  default='/home/erp/src', show_default=True),
     click.option('--sudo_user', help='Sudo user from the host', default='erp', show_default=True),
 ]
@@ -93,8 +94,10 @@ def configure_logging():
     logging.basicConfig(level=log_level)
 
 
-def configure_ssh_auth():
+def configure_ssh_auth(proxy=None):
     env.use_ssh_config = True
+    if proxy:
+        env.gateway = proxy
     ssh_key_path = os.environ.get('APPLY_PR_SSH_KEY_PATH')
     if ssh_key_path:
         env.key_filename = ssh_key_path
@@ -121,7 +124,8 @@ def apply_pr(
     pr, host, from_number=0, from_commit=None, force_hostname=False,
     owner='gisce', repository='erp', src='/home/erp/src', sudo_user='erp',
     auto_exit=True, force_name=None, re_deploy=False, as_diff=False, prs='',
-    environ='pre', reject=False, skip_rolling_check=False, exit_code_failure=False, no_set_label=False
+    environ='pre', reject=False, skip_rolling_check=False, exit_code_failure=False,
+    no_set_label=False, proxy=None
 ):
     """
     Deploy a PR into a remote server via Fabric
@@ -129,6 +133,8 @@ def apply_pr(
     :type pr:                   str
     :param host:                Host to connect
     :type host:                 str
+    :param proxy:               SSH proxy/jump host
+    :type proxy:                str
     :param from_number:         Number of the commit to deploy from
     :type from_number:          str
     :param from_commit:         Hash of the commit to deploy from
@@ -158,7 +164,7 @@ def apply_pr(
     url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password
-    configure_ssh_auth()
+    configure_ssh_auth(proxy=proxy)
     if not prs and not pr:
         click.echo(colors.red(
             u"\U000026D4 ERROR: You can't deploy nothing without indicate PR"
@@ -214,7 +220,10 @@ def deploy(**kwargs):
 @click.option('--force/--no-force', default=False,
               help='Forces the usage of this command')
 @add_options(deployment_options)
-def check_pr(pr, force, src, owner, repository, host):
+def check_pr(
+    pr, force, src, host, owner='gisce', repository='erp', proxy=None,
+    sudo_user='erp'
+):
     """DEPRECATED - Check for applied commits on PR"""
     print(colors.red("This option has been deprecated as it doesn't work"))
     if not force:
@@ -226,7 +235,7 @@ def check_pr(pr, force, src, owner, repository, host):
     url = urlparse(host, scheme='ssh')
     env.user = url.username
     env.password = url.password
-    configure_ssh_auth()
+    configure_ssh_auth(proxy=proxy)
 
     configure_logging()
 

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -50,6 +50,7 @@ class ConfigureSSHAuthTest(unittest.TestCase):
 
         self.assertTrue(fake_env.use_ssh_config)
         self.assertFalse(hasattr(fake_env, 'key_filename'))
+        self.assertFalse(hasattr(fake_env, 'gateway'))
 
     def test_uses_apply_pr_ssh_key_path_when_configured(self):
         os.environ['APPLY_PR_SSH_KEY_PATH'] = '/tmp/sastre_id_rsa'
@@ -58,6 +59,12 @@ class ConfigureSSHAuthTest(unittest.TestCase):
 
         self.assertTrue(fake_env.use_ssh_config)
         self.assertEqual(fake_env.key_filename, '/tmp/sastre_id_rsa')
+
+    def test_uses_proxy_as_ssh_gateway_when_configured(self):
+        cli.configure_ssh_auth(proxy='gisce@proxy.example.net')
+
+        self.assertTrue(fake_env.use_ssh_config)
+        self.assertEqual(fake_env.gateway, 'gisce@proxy.example.net')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Add a deploy/check_pr `--proxy` option and wire it to Fabric `env.gateway` for SSH jump hosts.
- Keep existing SSH config and `APPLY_PR_SSH_KEY_PATH` behavior intact.
- Document the option with an `ssh -J` equivalent example.

Closes #172

## Tests
- `python3 -m unittest tests.test_cli_ssh_auth`
- `python3 -m unittest discover -s tests -p 'test*.py'`

## Notes
- TASK ERP was requested by the curated workflow, but this runtime only has local ERP profiles available; production ERP credentials are not configured, so I could not create a real erp-ti task for project 9459.