### PR TITLE
Add local pull request deployment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Apply pull requests
 
-Fabric tools to apply pull requests in servers using `git format-patch` and
-`git am`.
+Tools to apply pull requests to remote servers or local checkouts using
+`git format-patch` and `git am`.
 Is integrated with the new [deployment
 API](https://developer.github.com/v3/repos/deployments/) from GitHub.
 
@@ -13,6 +13,13 @@ be provided explicitly, set `APPLY_PR_SSH_KEY_PATH` with the key file path
 before running the command. When the target host requires a jump server, pass
 `--proxy user@proxy-host`, equivalent to using `ssh -J user@proxy-host`.
 
+Local deployments use `--local` and execute Git directly in the target checkout;
+they do not open an SSH connection and do not use `sudo`. `--src` keeps the same
+meaning in both modes: it is the parent directory containing the repository.
+For example, `--src /home/user/src --repository erp` targets
+`/home/user/src/erp`. The local checkout must be clean before deployment so
+existing work cannot accidentally be included in the applied PR.
+
 ## Command line scripts
 
 This repository uses the [Click](http://click.pocoo.org/5/) package to
@@ -22,7 +29,7 @@ The following commands are supported with `sastre`:
 
 | Console Command    | Description                                                         | Wiki page                                                                                          |
 |:---------------:   |:--------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| `deploy`           | Apply a PR to a remote server                                       | [Deploy a pull request](https://github.com/gisce/apply_pr/wiki/Apply-a-Pull-Request)               |
+| `deploy`           | Apply a PR to a remote server or local checkout                     | [Deploy a pull request](https://github.com/gisce/apply_pr/wiki/Apply-a-Pull-Request)               |
 | `check_prs`        | Check the status of the PRs for a set of PRs                        | [Check pull requests status](https://github.com/gisce/apply_pr/wiki/Check-pull-requests-status)    |
 | `status`           | Update the status of a deploy into GitHub                           | [Mark deploy status](https://github.com/gisce/apply_pr/wiki/Mark-deploy-status)                    |
 | `create_changelog` | Create a chnagelog for the given milestone                          | [Create Changelog](https://github.com/gisce/apply_pr/wiki/Create-Changelog)                        |
@@ -46,8 +53,10 @@ Usage: deploy [OPTIONS]
 
 Options:
   --pr TEXT              Pull request to deploy  [required]
-  --host TEXT            Host to where to be deployed  [required]
+  --host TEXT            Remote host (required unless --local is used)
+  --local                Apply directly to a local checkout without SSH
   --proxy TEXT           SSH proxy/jump host
+  --src TEXT             Parent path containing the repository
   --from-number INTEGER  From commit number
   --from-commit TEXT     From commit hash (included)
   --force-hostname TEXT  Force hostname  [default: False]
@@ -55,6 +64,13 @@ Options:
   --repository TEXT      GitHub repository name  [default: erp]
   --src TEXT             Remote src path  [default: /home/erp/src]
   --help                 Show this message and exit.
+```
+
+Local example:
+
+```bash
+sastre deploy --local --src /home/user/src --repository erp \
+  --pr 1234 --environ test
 ```
 
 ### STATUS

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -20,14 +20,20 @@ github_options = [
 
 ]
 
-deployment_options = [
-    click.option("--host", help="Host to apply", required=True),
+deployment_path_options = [
     click.option('--proxy', help='SSH proxy/jump host'),
-    click.option('--src', help='Remote src path',  default='/home/erp/src', show_default=True),
+    click.option('--src', help='Parent path containing the repository',  default='/home/erp/src', show_default=True),
     click.option('--sudo_user', help='Sudo user from the host', default='erp', show_default=True),
 ]
 
-apply_pr_options = github_options + deployment_options + [
+deployment_options = [
+    click.option("--host", help="Remote host to apply", required=True),
+] + deployment_path_options
+
+apply_pr_options = github_options + [
+    click.option("--host", help="Remote host to apply"),
+    click.option("--local", "local_mode", help="Apply directly to a local checkout without SSH", is_flag=True, default=False),
+] + deployment_path_options + [
     click.option("--pr", help="Pull request to apply", default='',required=True),
     click.option("--environ", help="Environment to deploy", type=click.Choice(['pro', 'pre', 'test']), required=True),
     click.option("--from-number", help="From commit number", default=0),
@@ -103,6 +109,16 @@ def configure_ssh_auth(proxy=None):
         env.key_filename = ssh_key_path
 
 
+def validate_deployment_target(local_mode=False, host=None, proxy=None):
+    if local_mode:
+        if host:
+            raise click.UsageError("--host cannot be used together with --local")
+        if proxy:
+            raise click.UsageError("--proxy cannot be used together with --local")
+    elif not host:
+        raise click.UsageError("--host is required unless --local is used")
+
+
 @click.command('apply_pr')
 @add_options(apply_pr_options)
 def deprecated(**kwargs):
@@ -121,20 +137,22 @@ def sastre(**kwargs):
 
 
 def apply_pr(
-    pr, host, from_number=0, from_commit=None, force_hostname=False,
+    pr, host=None, from_number=0, from_commit=None, force_hostname=False,
     owner='gisce', repository='erp', src='/home/erp/src', sudo_user='erp',
     auto_exit=True, force_name=None, re_deploy=False, as_diff=False, prs='',
     environ='pre', reject=False, skip_rolling_check=False, exit_code_failure=False,
-    no_set_label=False, proxy=None
+    no_set_label=False, proxy=None, local_mode=False
 ):
     """
-    Deploy a PR into a remote server via Fabric
+    Deploy a PR into a remote server via Fabric or a local checkout
     :param pr:                  Number of the PR to deploy
     :type pr:                   str
     :param host:                Host to connect
     :type host:                 str
     :param proxy:               SSH proxy/jump host
     :type proxy:                str
+    :param local_mode:          Apply directly to the local checkout without SSH
+    :type local_mode:           bool
     :param from_number:         Number of the commit to deploy from
     :type from_number:          str
     :param from_commit:         Hash of the commit to deploy from
@@ -158,13 +176,18 @@ def apply_pr(
         ))
         sys.exit(1)
 
+    validate_deployment_target(
+        local_mode=local_mode, host=host, proxy=proxy
+    )
+
     from apply_pr import fabfile
-    if 'ssh' not in host and host[:2] != '//':
-        host = '//{}'.format(host)
-    url = urlparse(host, scheme='ssh')
-    env.user = url.username
-    env.password = url.password
-    configure_ssh_auth(proxy=proxy)
+    if not local_mode:
+        if 'ssh' not in host and host[:2] != '//':
+            host = '//{}'.format(host)
+        url = urlparse(host, scheme='ssh')
+        env.user = url.username
+        env.password = url.password
+        configure_ssh_auth(proxy=proxy)
     if not prs and not pr:
         click.echo(colors.red(
             u"\U000026D4 ERROR: You can't deploy nothing without indicate PR"
@@ -183,15 +206,29 @@ def apply_pr(
             )
         ))
         configure_logging()
-        apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
-        result = execute(
-            apply_pr_task, pr_dep, from_number, from_commit, hostname=force_hostname,
-            src=src, owner=owner, repository=repository, sudo_user=sudo_user,
-            host='{}:{}'.format(url.hostname, (url.port or 22)), auto_exit=auto_exit,
-            force_name=force_name, re_deploy=re_deploy, as_diff=as_diff,
-            environment=environ, reject=reject, skip_rolling_check=skip_rolling_check,
-            no_set_label=no_set_label
-        )
+        if local_mode:
+            from apply_pr.local import apply_pr as apply_pr_local
+            local_result = apply_pr_local(
+                fabfile, pr_dep, from_number=from_number,
+                from_commit=from_commit, hostname=force_hostname,
+                src=src, owner=owner, repository=repository,
+                auto_exit=auto_exit, force_name=force_name,
+                re_deploy=re_deploy, as_diff=as_diff,
+                environment=environ, reject=reject,
+                skip_rolling_check=skip_rolling_check,
+                no_set_label=no_set_label
+            )
+            result = {'local': local_result}
+        else:
+            apply_pr_task = WrappedCallableTask(fabfile.apply_pr)
+            result = execute(
+                apply_pr_task, pr_dep, from_number, from_commit, hostname=force_hostname,
+                src=src, owner=owner, repository=repository, sudo_user=sudo_user,
+                host='{}:{}'.format(url.hostname, (url.port or 22)), auto_exit=auto_exit,
+                force_name=force_name, re_deploy=re_deploy, as_diff=as_diff,
+                environment=environ, reject=reject, skip_rolling_check=skip_rolling_check,
+                no_set_label=no_set_label
+            )
         result_list = list(result.items())
         if not result_list[0][1]:
             failed_prs.append(pr_dep)
@@ -208,7 +245,7 @@ def apply_pr(
 @sastre.command(name="deploy")
 @add_options(apply_pr_options)
 def deploy(**kwargs):
-    """Deploy a PR into a remote server via Fabric"""
+    """Deploy a PR into a remote server or a local checkout"""
     if not isinstance(kwargs['pr'], (list, tuple)):
         from apply_pr.fabfile import get_info_from_url
         kwargs.update(get_info_from_url(kwargs['pr']))

--- a/apply_pr/local.py
+++ b/apply_pr/local.py
@@ -1,0 +1,422 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+import glob
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+
+import six
+from fabric import colors
+from tqdm import tqdm
+
+from apply_pr.exceptions import ApplyError
+
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    console_input = raw_input
+except NameError:
+    console_input = input
+
+
+class LocalApplyError(ApplyError):
+    pass
+
+
+class CommandResult(object):
+    def __init__(self, return_code, output):
+        self.return_code = return_code
+        self.output = output
+
+    @property
+    def failed(self):
+        return self.return_code != 0
+
+
+def _as_text(value):
+    if isinstance(value, six.text_type):
+        return value
+    if isinstance(value, bytes):
+        return value.decode('utf-8', 'replace')
+    try:
+        return six.text_type(value)
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        representation = repr(value)
+        if isinstance(representation, six.text_type):
+            return representation
+        return representation.decode('utf-8', 'replace')
+
+
+def _log_error(error, prefix=None):
+    message = _as_text(error)
+    if prefix:
+        message = '{}{}'.format(prefix, message)
+    if six.PY2:
+        # Python 2's logging formatter mixes its byte format with the Unicode
+        # record and tries to encode it as ASCII. An ASCII-only escaped value
+        # works with both byte and Unicode formatters; the console output still
+        # displays the original message as UTF-8.
+        logger.error(b'%s', message.encode('ascii', 'backslashreplace'))
+    else:
+        logger.error('%s', message)
+
+
+def _print_message(message):
+    message = _as_text(message)
+    if six.PY2:
+        sys.stdout.write(message.encode('utf-8', 'replace') + b'\n')
+    else:
+        sys.stdout.write(message + '\n')
+
+
+def _tqdm_write(message):
+    message = _as_text(message)
+    if six.PY2:
+        message = message.encode('utf-8', 'replace')
+    tqdm.write(message)
+
+
+def repository_path(src, repository):
+    """Return the checkout path using the same src/repository layout as SSH."""
+    return os.path.abspath(os.path.join(os.path.expanduser(src), repository))
+
+
+def _run_git(checkout, arguments, check=True):
+    command = ['git'] + list(arguments)
+    process = subprocess.Popen(
+        command,
+        cwd=checkout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    output = process.communicate()[0]
+    if not isinstance(output, six.text_type):
+        output = output.decode('utf-8', 'replace')
+    result = CommandResult(process.returncode, output)
+    if check and result.failed:
+        raise LocalApplyError(
+            "Command '{command}' failed in {checkout}:\n{output}".format(
+                command=' '.join(command),
+                checkout=checkout,
+                output=output.strip(),
+            )
+        )
+    return result
+
+
+def _git_path(checkout, name):
+    path = _run_git(
+        checkout, ['rev-parse', '--git-path', name]
+    ).output.strip()
+    if not os.path.isabs(path):
+        path = os.path.join(checkout, path)
+    return os.path.abspath(path)
+
+
+def validate_repository(checkout, skip_rolling_check=False):
+    """Validate the local target before any deployment is registered."""
+    if not os.path.isdir(checkout):
+        raise LocalApplyError(
+            'The local repository does not exist: {}'.format(checkout)
+        )
+
+    top_level = _run_git(
+        checkout, ['rev-parse', '--show-toplevel'], check=False
+    )
+    if top_level.failed:
+        raise LocalApplyError(
+            'The local target is not a Git repository: {}'.format(checkout)
+        )
+    if os.path.realpath(top_level.output.strip()) != os.path.realpath(checkout):
+        raise LocalApplyError(
+            'The local target must be the repository root: {}'.format(checkout)
+        )
+
+    if os.path.isdir(_git_path(checkout, 'rebase-apply')):
+        raise LocalApplyError(
+            'The local repository is in the middle of a git am session'
+        )
+
+    if not skip_rolling_check:
+        branch = _run_git(
+            checkout, ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+            check=False,
+        )
+        if branch.failed or branch.output.strip() != 'rolling':
+            raise LocalApplyError(
+                "The local repository is not on the 'rolling' branch"
+            )
+
+    status = _run_git(checkout, ['status', '--porcelain'])
+    if status.output.strip():
+        raise LocalApplyError(
+            'The local repository has uncommitted changes; clean or stash '
+            'them before deploying'
+        )
+
+
+@contextmanager
+def _working_directory(path):
+    previous = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _patch_number(path):
+    try:
+        return int(os.path.basename(path).split('-', 1)[0])
+    except (TypeError, ValueError):
+        return 0
+
+
+def _select_patches(workdir, pr_number, from_number=0):
+    patch_pattern = os.path.join(
+        workdir, 'deploy', 'patches', str(pr_number), '*.patch'
+    )
+    patches = sorted(glob.glob(patch_pattern))
+    from_number = int(from_number or 0)
+    if from_number:
+        patches = [
+            path for path in patches if _patch_number(path) >= from_number
+        ]
+    if not patches:
+        raise LocalApplyError(
+            'No patches found to apply for pull request #{}'.format(pr_number)
+        )
+    return patches
+
+
+def _apply_patches(checkout, patches, auto_exit=True, input_func=None):
+    input_func = input_func or console_input
+    progress = tqdm(total=len(patches), desc='   Applying')
+    try:
+        result = _run_git(checkout, ['am'] + patches, check=False)
+        while True:
+            for line in result.output.split('\n'):
+                if line.startswith('Applying: '):
+                    _tqdm_write(colors.green(line))
+                    progress.update()
+            if not result.failed:
+                return
+            if 'git config --global user.email' in result.output:
+                _log_error('Need to configure git for this user')
+                raise LocalApplyError(result.output.strip())
+            if auto_exit:
+                _run_git(checkout, ['am', '--abort'], check=False)
+                logger.error('Aborting deploy and go back')
+                raise LocalApplyError(result.output.strip())
+
+            input_func(
+                'Resolve the git am conflict, stage the resolution and press '
+                'Enter to continue: '
+            )
+            staged = _run_git(
+                checkout,
+                ['diff', '--cached', '--name-only', '--no-color'],
+            ).output.strip()
+            action = '--continue' if staged else '--skip'
+            result = _run_git(checkout, ['am', action], check=False)
+    finally:
+        progress.close()
+
+
+def _apply_diff(
+    checkout, diff_path, pr_number, reject=False, input_func=None
+):
+    input_func = input_func or console_input
+    arguments = ['apply']
+    if reject:
+        arguments.append('--reject')
+    arguments.append(diff_path)
+    _print_message(colors.green('Applying diff {}'.format(diff_path)))
+    result = _run_git(checkout, arguments, check=False)
+    if result.failed and not reject:
+        raise LocalApplyError(result.output.strip())
+    if result.failed:
+        _print_message(colors.yellow('Some rejects ...'))
+        input_func(
+            'Some hunks were rejected. Resolve them and press Enter to '
+            'continue: '
+        )
+
+    changed = _run_git(checkout, ['status', '--porcelain']).output.strip()
+    if not changed:
+        _print_message(colors.green('Nothing to commit! Continue'))
+        return
+    _print_message(colors.green('Commit!'))
+    _run_git(checkout, ['add', '-A'])
+    _run_git(
+        checkout,
+        ['commit', '-m', 'Apply pull request #{}'.format(pr_number)],
+    )
+
+
+def _mark_failure(
+    backend, deploy_id, error, owner, repository, no_set_label
+):
+    try:
+        backend.mark_deploy_status(
+            deploy_id,
+            state='error',
+            description='{}'.format(error),
+            owner=owner,
+            repository=repository,
+            no_set_label=no_set_label,
+        )
+    except Exception as status_error:
+        _log_error(
+            status_error,
+            prefix='Could not mark the local deployment as failed: ',
+        )
+
+
+def apply_pr(
+    backend, pr_number, from_number=0, from_commit=None, hostname=False,
+    src='/home/erp/src', owner='gisce', repository='erp', auto_exit=False,
+    force_name=None, re_deploy=False, as_diff=False, environment='pro',
+    reject=False, skip_rolling_check=False, no_set_label=False,
+    input_func=None
+):
+    """Apply a GitHub pull request directly to a local checkout."""
+    repository_name = force_name or repository
+    checkout = repository_path(src, repository_name)
+    hostname = hostname or socket.gethostname()
+    input_func = input_func or console_input
+
+    try:
+        validate_repository(
+            checkout, skip_rolling_check=skip_rolling_check
+        )
+
+        if re_deploy:
+            _tqdm_write(colors.blue(
+                '\U0001F50E Trying to find last success deploymnet...'
+            ))
+            last_deploy, from_commit = backend.get_last_deploy(
+                pr_number, hostname, owner, repository
+            )
+            if last_deploy:
+                _tqdm_write(colors.blue(
+                    '\U00002705 Got it! is {sha}.'.format(**last_deploy)
+                ))
+                if last_deploy['sha'] == from_commit:
+                    _tqdm_write(colors.red(
+                        '\U000026D4 No commits to deploy...'
+                    ))
+                    raise LocalApplyError('No commits to deploy')
+            else:
+                _tqdm_write(colors.blue('\U0001F62F Not found...'))
+            response = input_func(
+                'Deploy locally from {}? (y/n): '.format(from_commit or '0')
+            )
+            if response.upper() != 'Y':
+                raise LocalApplyError('Local deployment cancelled')
+
+        deploy_id = backend.mark_to_deploy(
+            pr_number,
+            hostname=hostname,
+            owner=owner,
+            repository=repository,
+        )
+    except Exception as error:
+        _log_error(error)
+        _tqdm_write(colors.red('Deploy failure \U0001F680'))
+        return False
+
+    if not deploy_id:
+        _tqdm_write(colors.magenta(
+            'No deploy id! you must mark the Pull Request manually'
+        ))
+
+    workdir = tempfile.mkdtemp(prefix='sastre-local-')
+    try:
+        backend.mark_deploy_status(
+            deploy_id,
+            state='pending',
+            owner=owner,
+            repository=repository,
+            environment=environment,
+            no_set_label=no_set_label,
+        )
+        _tqdm_write(colors.yellow(
+            'Marking to deploy ({}) \U0001F680'.format(deploy_id)
+        ))
+        with _working_directory(workdir):
+            if as_diff:
+                backend.export_diff_from_github(
+                    pr_number, owner=owner, repository=repository
+                )
+            else:
+                backend.export_patches_from_github(
+                    pr_number,
+                    from_commit,
+                    owner=owner,
+                    repository=repository,
+                )
+
+        if as_diff:
+            _tqdm_write(colors.yellow('Applying diff \U0001F648'))
+            diff_path = os.path.join(
+                workdir, 'deploy', 'patches', '{}.diff'.format(pr_number)
+            )
+            if not os.path.isfile(diff_path):
+                raise LocalApplyError(
+                    'The pull request diff was not downloaded'
+                )
+            _apply_diff(
+                checkout,
+                diff_path,
+                pr_number,
+                reject=reject,
+                input_func=input_func,
+            )
+        else:
+            _tqdm_write(colors.yellow('Applying patches \U0001F648'))
+            patches = _select_patches(
+                workdir,
+                pr_number,
+                from_number=0 if from_commit else from_number,
+            )
+            _apply_patches(
+                checkout,
+                patches,
+                auto_exit=auto_exit,
+                input_func=input_func,
+            )
+
+        backend.mark_deploy_status(
+            deploy_id,
+            state='success',
+            owner=owner,
+            repository=repository,
+            pr_number=pr_number,
+            no_set_label=no_set_label,
+            environment=environment,
+        )
+        _tqdm_write(colors.green('Deploy success \U0001F680'))
+        return True
+    except Exception as error:
+        _log_error(error)
+        _mark_failure(
+            backend,
+            deploy_id,
+            error,
+            owner,
+            repository,
+            no_set_label,
+        )
+        _tqdm_write(colors.red('Deploy failure \U0001F680'))
+        return False
+    finally:
+        shutil.rmtree(workdir)

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -34,6 +34,8 @@ sys.modules.setdefault('fabric.api', fake_fabric_api)
 sys.modules.setdefault('fabric.colors', fake_fabric_colors)
 
 import apply_pr.cli as cli
+import apply_pr.local as local_backend
+import apply_pr as apply_pr_package
 
 
 class ConfigureSSHAuthTest(unittest.TestCase):
@@ -65,6 +67,76 @@ class ConfigureSSHAuthTest(unittest.TestCase):
 
         self.assertTrue(fake_env.use_ssh_config)
         self.assertEqual(fake_env.gateway, 'gisce@proxy.example.net')
+
+
+class DeploymentTargetValidationTest(unittest.TestCase):
+    def test_remote_mode_requires_host(self):
+        with self.assertRaises(cli.click.UsageError):
+            cli.validate_deployment_target()
+
+    def test_local_mode_does_not_require_host(self):
+        cli.validate_deployment_target(local_mode=True)
+
+    def test_local_mode_rejects_host(self):
+        with self.assertRaises(cli.click.UsageError):
+            cli.validate_deployment_target(
+                local_mode=True, host='erp.example.net'
+            )
+
+    def test_local_mode_rejects_ssh_proxy(self):
+        with self.assertRaises(cli.click.UsageError):
+            cli.validate_deployment_target(
+                local_mode=True, proxy='proxy.example.net'
+            )
+
+    def test_local_mode_bypasses_fabric_execute_and_ssh_configuration(self):
+        calls = []
+        fake_fabfile = types.ModuleType(str('apply_pr.fabfile'))
+        old_fabfile = sys.modules.get('apply_pr.fabfile')
+        old_package_fabfile = getattr(
+            apply_pr_package, 'fabfile', None
+        )
+        old_local_apply = local_backend.apply_pr
+        old_execute = cli.execute
+        old_configure_ssh_auth = cli.configure_ssh_auth
+
+        def fake_local_apply(backend, pr_number, **kwargs):
+            calls.append((backend, pr_number, kwargs))
+            return True
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError('SSH/Fabric remote execution was used')
+
+        try:
+            sys.modules['apply_pr.fabfile'] = fake_fabfile
+            apply_pr_package.fabfile = fake_fabfile
+            local_backend.apply_pr = fake_local_apply
+            cli.execute = forbidden
+            cli.configure_ssh_auth = forbidden
+
+            result = cli.apply_pr(
+                '42',
+                local_mode=True,
+                src='/srv/src',
+                repository='erp',
+                environ='test',
+            )
+        finally:
+            local_backend.apply_pr = old_local_apply
+            cli.execute = old_execute
+            cli.configure_ssh_auth = old_configure_ssh_auth
+            if old_fabfile is None:
+                sys.modules.pop('apply_pr.fabfile', None)
+            else:
+                sys.modules['apply_pr.fabfile'] = old_fabfile
+            if old_package_fabfile is None:
+                delattr(apply_pr_package, 'fabfile')
+            else:
+                apply_pr_package.fabfile = old_package_fabfile
+
+        self.assertEqual(result, [{'local': True}])
+        self.assertEqual(calls[0][0], fake_fabfile)
+        self.assertEqual(calls[0][1], '42')
 
 
 if __name__ == '__main__':

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import os
+import io
+import logging
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import six
+
+from apply_pr import local
+
+
+class FakeBackend(object):
+    def __init__(self, patch_path):
+        self.patch_path = patch_path
+        self.statuses = []
+        self.deployments = []
+
+    def mark_to_deploy(
+        self, pr_number, hostname=False, owner='gisce', repository='erp'
+    ):
+        self.deployments.append((pr_number, hostname, owner, repository))
+        return 123
+
+    def mark_deploy_status(self, deploy_id, state='success', **kwargs):
+        self.statuses.append((deploy_id, state, kwargs))
+
+    def export_patches_from_github(
+        self, pr_number, from_commit=None, owner='gisce', repository='erp'
+    ):
+        destination = os.path.join(
+            'deploy', 'patches', str(pr_number)
+        )
+        os.makedirs(destination)
+        shutil.copy(
+            self.patch_path,
+            os.path.join(destination, os.path.basename(self.patch_path)),
+        )
+
+
+class LocalDeploymentTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp(prefix='apply-pr-test-')
+        self.src = os.path.join(self.tempdir, 'src')
+        self.checkout = os.path.join(self.src, 'erp')
+        os.makedirs(self.checkout)
+        self._git('init', '-q')
+        self._git('config', 'user.name', 'Sastre Test')
+        self._git('config', 'user.email', 'sastre@example.net')
+        self._git('checkout', '-q', '-b', 'rolling')
+        self._write('message.txt', 'before\n')
+        self._git('add', 'message.txt')
+        self._git('commit', '-q', '-m', 'Initial commit')
+        self.patch_path = self._create_patch()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def _git(self, *arguments):
+        output = subprocess.check_output(
+            ['git'] + list(arguments),
+            cwd=self.checkout,
+            stderr=subprocess.STDOUT,
+        )
+        return output.decode('utf-8', 'replace')
+
+    def _write(self, path, value):
+        with open(os.path.join(self.checkout, path), 'w') as stream:
+            stream.write(value)
+
+    def _create_patch(self):
+        self._write('message.txt', 'after\n')
+        self._git('add', 'message.txt')
+        self._git('commit', '-q', '-m', 'Change greeting')
+        patch = subprocess.check_output(
+            ['git', 'format-patch', '-1', '--stdout'],
+            cwd=self.checkout,
+            stderr=subprocess.STDOUT,
+        )
+        patch_path = os.path.join(
+            self.tempdir, '0001-change-greeting.patch'
+        )
+        with open(patch_path, 'wb') as stream:
+            stream.write(patch)
+        self._git('reset', '-q', '--hard', 'HEAD^')
+        return patch_path
+
+    def test_applies_patch_without_ssh_and_updates_deployment(self):
+        backend = FakeBackend(self.patch_path)
+
+        result = local.apply_pr(
+            backend,
+            '42',
+            src=self.src,
+            repository='erp',
+            environment='test',
+            auto_exit=True,
+        )
+
+        self.assertTrue(result)
+        with open(os.path.join(self.checkout, 'message.txt')) as stream:
+            self.assertEqual(stream.read(), 'after\n')
+        self.assertEqual(self._git('log', '-1', '--format=%s').strip(),
+                         'Change greeting')
+        self.assertEqual(
+            [status[1] for status in backend.statuses],
+            ['pending', 'success'],
+        )
+
+    def test_rejects_dirty_checkout_before_registering_deployment(self):
+        backend = FakeBackend(self.patch_path)
+        self._write('message.txt', 'dirty\n')
+
+        result = local.apply_pr(
+            backend,
+            '42',
+            src=self.src,
+            repository='erp',
+            auto_exit=True,
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(backend.deployments, [])
+
+    def test_requires_rolling_branch_by_default(self):
+        backend = FakeBackend(self.patch_path)
+        self._git('checkout', '-q', '-b', 'feature')
+
+        result = local.apply_pr(
+            backend,
+            '42',
+            src=self.src,
+            repository='erp',
+            auto_exit=True,
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(backend.deployments, [])
+
+    def test_uses_the_same_progress_messages_as_remote_deploy(self):
+        messages = []
+        updates = []
+
+        class FakeTqdm(object):
+            def __init__(self, total=None, desc=None):
+                self.total = total
+                self.desc = desc
+
+            @staticmethod
+            def write(message):
+                messages.append(local._as_text(message))
+
+            def update(self, amount=1):
+                updates.append(amount)
+
+            def close(self):
+                pass
+
+        class FakeColors(object):
+            blue = staticmethod(lambda message: message)
+            green = staticmethod(lambda message: message)
+            magenta = staticmethod(lambda message: message)
+            red = staticmethod(lambda message: message)
+            yellow = staticmethod(lambda message: message)
+
+        backend = FakeBackend(self.patch_path)
+        old_tqdm = local.tqdm
+        old_colors = local.colors
+        try:
+            local.tqdm = FakeTqdm
+            local.colors = FakeColors
+            result = local.apply_pr(
+                backend,
+                '42',
+                src=self.src,
+                repository='erp',
+                auto_exit=True,
+            )
+        finally:
+            local.tqdm = old_tqdm
+            local.colors = old_colors
+
+        self.assertTrue(result)
+        self.assertIn(u'Marking to deploy (123) \U0001F680', messages)
+        self.assertIn(u'Applying patches \U0001F648', messages)
+        self.assertIn(u'Applying: Change greeting', messages)
+        self.assertIn(u'Deploy success \U0001F680', messages)
+        self.assertEqual(updates, [1])
+
+
+class UnicodeLoggingTest(unittest.TestCase):
+    def test_logs_unicode_exception_without_ascii_encoding_error(self):
+        class LoggingCapture(object):
+            encoding = 'utf-8'
+
+            def __init__(self):
+                self.value = u''
+
+            def write(self, value):
+                if not isinstance(value, six.text_type):
+                    value = value.decode('utf-8')
+                self.value += value
+
+            def flush(self):
+                pass
+
+            def getvalue(self):
+                return self.value
+
+        stream = LoggingCapture()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter(
+            str('%(levelname)s:%(name)s:%(message)s')
+        ))
+        old_handlers = local.logger.handlers[:]
+        old_level = local.logger.level
+        old_propagate = local.logger.propagate
+        try:
+            local.logger.handlers = [handler]
+            local.logger.setLevel(logging.ERROR)
+            local.logger.propagate = False
+
+            local._log_error(
+                local.LocalApplyError(u"No s'ha pogut aplicar el pedaç")
+            )
+        finally:
+            local.logger.handlers = old_handlers
+            local.logger.setLevel(old_level)
+            local.logger.propagate = old_propagate
+
+        output = stream.getvalue()
+        if six.PY2:
+            self.assertIn(u'peda\\xe7', output)
+        else:
+            self.assertIn(u'pedaç', output)
+
+    def test_prints_unicode_message_as_utf8(self):
+        if six.PY2:
+            stream = io.BytesIO()
+        else:
+            stream = io.StringIO()
+        old_stdout = sys.stdout
+        try:
+            sys.stdout = stream
+            local._print_message(u"No s'ha pogut aplicar el pedaç")
+        finally:
+            sys.stdout = old_stdout
+
+        output = stream.getvalue()
+        if not isinstance(output, six.text_type):
+            output = output.decode('utf-8')
+        self.assertIn(u'pedaç', output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a `--local` deployment mode that applies pull requests directly to a local checkout without SSH or `sudo`
- preserve GitHub deployment creation, status updates, labels, `--from-*`, `--as-diff`, `--reject`, and `--re-deploy` behavior
- validate the local repository before deployment, including clean worktree, `rolling` branch, and incomplete `git am` checks
- mirror the remote deployment output with the same colors, emojis, deployment ID messages, and `tqdm` progress
- handle Unicode logging and terminal output safely on both Python 2.7 and Python 3.11
- document the new mode and its path semantics

## Why

The existing deployment flow always dispatches Fabric remote operations, so applying a pull request to a local checkout still requires an SSH server. This adds a real local execution backend while keeping the established GitHub deployment workflow and user-facing behavior.

## Impact

Users can now run, for example:

```bash
sastre deploy --local --src /home/user/src --repository erp \
  --pr 1234 --environ test
```

The target checkout must be clean and on `rolling` unless `--skip-rolling-check` is supplied. Remote SSH deployment behavior remains unchanged.

## Validation

- Python 2.7.18: 15 tests passed
- Python 3.11.5: 15 tests passed
- syntax compilation passed in both interpreters
- `git diff --check` passed
