### PR TITLE
Add squash option for successful deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options:
   --src TEXT             Parent path containing the repository
   --from-number INTEGER  From commit number
   --from-commit TEXT     From commit hash (included)
+  --squash               Squash successfully applied commits into one
   --force-hostname TEXT  Force hostname  [default: False]
   --owner TEXT           GitHub owner name  [default: gisce]
   --repository TEXT      GitHub repository name  [default: erp]

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -46,6 +46,8 @@ apply_pr_options = github_options + [
                 is_flag=True, default=False),
     click.option("--as-diff", help="Apply pull request as unique diff",
                  is_flag=True, default=False),
+    click.option("--squash", help="Squash successfully applied commits into one",
+                 is_flag=True, default=False),
     click.option("--prs", help="Pull request to apply", default=''),
     click.option("--reject", help="Use reject to deploy diff", is_flag=True, default=False),
     click.option("--skip-rolling-check", help="Allow to skip rolling branch check", is_flag=True, default=False),
@@ -141,7 +143,7 @@ def apply_pr(
     owner='gisce', repository='erp', src='/home/erp/src', sudo_user='erp',
     auto_exit=True, force_name=None, re_deploy=False, as_diff=False, prs='',
     environ='pre', reject=False, skip_rolling_check=False, exit_code_failure=False,
-    no_set_label=False, proxy=None, local_mode=False
+    no_set_label=False, proxy=None, local_mode=False, squash=False
 ):
     """
     Deploy a PR into a remote server via Fabric or a local checkout
@@ -214,6 +216,7 @@ def apply_pr(
                 src=src, owner=owner, repository=repository,
                 auto_exit=auto_exit, force_name=force_name,
                 re_deploy=re_deploy, as_diff=as_diff,
+                squash=squash,
                 environment=environ, reject=reject,
                 skip_rolling_check=skip_rolling_check,
                 no_set_label=no_set_label
@@ -226,6 +229,7 @@ def apply_pr(
                 src=src, owner=owner, repository=repository, sudo_user=sudo_user,
                 host='{}:{}'.format(url.hostname, (url.port or 22)), auto_exit=auto_exit,
                 force_name=force_name, re_deploy=re_deploy, as_diff=as_diff,
+                squash=squash,
                 environment=environ, reject=reject, skip_rolling_check=skip_rolling_check,
                 no_set_label=no_set_label
             )

--- a/apply_pr/fabfile.py
+++ b/apply_pr/fabfile.py
@@ -145,7 +145,7 @@ def apply_remote_diff(pr_number, src='/home/erp/src', repository='erp',
 @task
 def apply_remote_patches(
     name, from_patch=0, src='/home/erp/src', repository='erp', sudo_user='erp',
-    auto_exit=True
+    auto_exit=True, squash=False
 ):
     from_commit = None
     if isinstance(from_patch, string_types) and len(from_patch) == 40:
@@ -178,10 +178,20 @@ def apply_remote_patches(
 
         if patches_to_apply:
             with cd("{}/{}".format(src, repository)):
+                previous_head = None
+                if squash:
+                    previous_head = sudo("git rev-parse HEAD").strip()
                 git_am = GitApplier(patches_to_apply)
                 if auto_exit:
                     git_am.auto_exit = True
                 git_am.run()
+                if squash:
+                    sudo(
+                        "git reset --soft {head} && "
+                        "git commit -m 'Apply pull request #{name}'".format(
+                            head=previous_head, name=name
+                        )
+                    )
 
 
 class WiggleException(Exception):
@@ -711,7 +721,8 @@ def apply_pr(
         pr_number, from_number=0, from_commit=None, skip_upload=False,
         hostname=False, src='/home/erp/src', owner='gisce', repository='erp',
         sudo_user='erp', auto_exit=False, force_name=None, re_deploy=False,
-        as_diff=False, environment='pro', reject=False, skip_rolling_check=False, no_set_label=False
+        as_diff=False, environment='pro', reject=False,
+        skip_rolling_check=False, no_set_label=False, squash=False
 ):
     if force_name:
         repository_name = force_name
@@ -798,6 +809,7 @@ def apply_pr(
                 repository=repository_name,
                 sudo_user=sudo_user,
                 auto_exit=auto_exit,
+                squash=squash,
             )
         mark_deploy_status(deploy_id,
                            state='success',

--- a/apply_pr/local.py
+++ b/apply_pr/local.py
@@ -197,9 +197,17 @@ def _select_patches(workdir, pr_number, from_number=0):
     return patches
 
 
-def _apply_patches(checkout, patches, auto_exit=True, input_func=None):
+def _apply_patches(
+    checkout, patches, auto_exit=True, input_func=None, squash=False,
+    pr_number=None
+):
     input_func = input_func or console_input
     progress = tqdm(total=len(patches), desc='   Applying')
+    previous_head = None
+    if squash:
+        previous_head = _run_git(
+            checkout, ['rev-parse', 'HEAD']
+        ).output.strip()
     try:
         result = _run_git(checkout, ['am'] + patches, check=False)
         while True:
@@ -208,6 +216,15 @@ def _apply_patches(checkout, patches, auto_exit=True, input_func=None):
                     _tqdm_write(colors.green(line))
                     progress.update()
             if not result.failed:
+                if squash:
+                    _run_git(checkout, ['reset', '--soft', previous_head])
+                    _run_git(
+                        checkout,
+                        [
+                            'commit', '-m',
+                            'Apply pull request #{}'.format(pr_number),
+                        ],
+                    )
                 return
             if 'git config --global user.email' in result.output:
                 _log_error('Need to configure git for this user')
@@ -286,7 +303,7 @@ def apply_pr(
     src='/home/erp/src', owner='gisce', repository='erp', auto_exit=False,
     force_name=None, re_deploy=False, as_diff=False, environment='pro',
     reject=False, skip_rolling_check=False, no_set_label=False,
-    input_func=None
+    input_func=None, squash=False
 ):
     """Apply a GitHub pull request directly to a local checkout."""
     repository_name = force_name or repository
@@ -393,6 +410,8 @@ def apply_pr(
                 patches,
                 auto_exit=auto_exit,
                 input_func=input_func,
+                squash=squash,
+                pr_number=pr_number,
             )
 
         backend.mark_deploy_status(

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -112,6 +112,63 @@ class LocalDeploymentTest(unittest.TestCase):
             ['pending', 'success'],
         )
 
+    def test_squashes_successfully_applied_commits(self):
+        self._git('am', self.patch_path)
+        self._write('second.txt', 'second change\n')
+        self._git('add', 'second.txt')
+        self._git('commit', '-q', '-m', 'Second change')
+        second_patch = os.path.join(
+            self.tempdir, '0002-second-change.patch'
+        )
+        with open(second_patch, 'wb') as stream:
+            stream.write(subprocess.check_output(
+                ['git', 'format-patch', '-1', '--stdout'],
+                cwd=self.checkout,
+                stderr=subprocess.STDOUT,
+            ))
+        self._git('reset', '-q', '--hard', 'HEAD~2')
+
+        class TwoPatchBackend(FakeBackend):
+            def export_patches_from_github(
+                backend_self, pr_number, from_commit=None,
+                owner='gisce', repository='erp'
+            ):
+                destination = os.path.join(
+                    'deploy', 'patches', str(pr_number)
+                )
+                os.makedirs(destination)
+                for patch in (self.patch_path, second_patch):
+                    shutil.copy(
+                        patch,
+                        os.path.join(destination, os.path.basename(patch)),
+                    )
+
+        backend = TwoPatchBackend(self.patch_path)
+        before = self._git('rev-parse', 'HEAD').strip()
+
+        result = local.apply_pr(
+            backend,
+            '42',
+            src=self.src,
+            repository='erp',
+            auto_exit=True,
+            squash=True,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            self._git('rev-list', '--count', '{}..HEAD'.format(before)).strip(),
+            '1',
+        )
+        self.assertEqual(
+            self._git('log', '-1', '--format=%s').strip(),
+            'Apply pull request #42',
+        )
+        with open(os.path.join(self.checkout, 'message.txt')) as stream:
+            self.assertEqual(stream.read(), 'after\n')
+        with open(os.path.join(self.checkout, 'second.txt')) as stream:
+            self.assertEqual(stream.read(), 'second change\n')
+
     def test_rejects_dirty_checkout_before_registering_deployment(self):
         backend = FakeBackend(self.patch_path)
         self._write('message.txt', 'dirty\n')


### PR DESCRIPTION
Closes #37.

## Summary

- add `--squash` to remote and local deployments
- squash only after every selected patch has applied successfully
- preserve re-deploy behavior by continuing to select incremental patches from GitHub deployment statuses
- document the option and cover the resulting history and working tree with a two-commit regression test

## Tests

- `PYTHONPATH=<temporary dependency directory> /home/openclaw/.pyenv/versions/erp3/bin/pytest -q` — 16 passed

## Traceability

Requested by: @ecarreras

An ERP task could not be created because this agent has no production ERP profile configured; only local profiles are available.
