### PR TITLE
Accept owner/repository in --repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,13 @@ Options:
 Local example:
 
 ```bash
-sastre deploy --local --src /home/user/src --repository erp \
+sastre deploy --local --src /home/user/src --repository gisce/erp \
   --pr 1234 --environ test
 ```
+
+`--repository` accepts either a repository name or the `owner/repository`
+format. The latter sets both values and takes precedence over `--owner`.
+`--owner` remains available for backwards compatibility.
 
 ### STATUS
 

--- a/apply_pr/cli.py
+++ b/apply_pr/cli.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from functools import wraps
 import six
 if six.PY2:
     from urlparse import urlparse
@@ -87,9 +88,24 @@ mark_deployed_options = github_options + [
 
 def add_options(options):
     def _add_options(func):
+        @wraps(func)
+        def _normalize_github_repository(*args, **kwargs):
+            repository = kwargs.get('repository')
+            if repository and '/' in repository:
+                parts = repository.split('/')
+                if len(parts) != 2 or not all(parts):
+                    raise click.BadParameter(
+                        "must be a repository name or use the 'owner/repository' format",
+                        param_hint='--repository',
+                    )
+                kwargs['owner'], kwargs['repository'] = parts
+            return func(*args, **kwargs)
+
         for option in reversed(options):
-            func = option(func)
-        return func
+            _normalize_github_repository = option(
+                _normalize_github_repository
+            )
+        return _normalize_github_repository
     return _add_options
 
 

--- a/tests/test_cli_ssh_auth.py
+++ b/tests/test_cli_ssh_auth.py
@@ -6,6 +6,9 @@ import sys
 import types
 import unittest
 
+import click
+from click.testing import CliRunner
+
 
 class DummyEnv(object):
     pass
@@ -36,6 +39,55 @@ sys.modules.setdefault('fabric.colors', fake_fabric_colors)
 import apply_pr.cli as cli
 import apply_pr.local as local_backend
 import apply_pr as apply_pr_package
+
+
+@click.command()
+@cli.add_options(cli.github_options)
+def repository_options(owner, repository):
+    click.echo('{}/{}'.format(owner, repository))
+
+
+class RepositoryOptionsTest(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_repository_accepts_owner_and_repository(self):
+        result = self.runner.invoke(
+            repository_options,
+            ['--repository', 'gisce/apply_pr'],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output.strip(), 'gisce/apply_pr')
+
+    def test_qualified_repository_overrides_owner_for_any_argument_order(self):
+        invocations = [
+            ['--owner', 'wrong', '--repository', 'gisce/apply_pr'],
+            ['--repository', 'gisce/apply_pr', '--owner', 'wrong'],
+        ]
+
+        for arguments in invocations:
+            result = self.runner.invoke(repository_options, arguments)
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.output.strip(), 'gisce/apply_pr')
+
+    def test_separate_owner_and_repository_remain_supported(self):
+        result = self.runner.invoke(
+            repository_options,
+            ['--owner', 'gisce', '--repository', 'erp'],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output.strip(), 'gisce/erp')
+
+    def test_rejects_invalid_qualified_repository(self):
+        result = self.runner.invoke(
+            repository_options,
+            ['--repository', 'gisce/apply_pr/extra'],
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("owner/repository", result.output)
 
 
 class ConfigureSSHAuthTest(unittest.TestCase):


### PR DESCRIPTION
Closes #176

## Summary

- accept `owner/repository` through `--repository` across shared GitHub options
- keep separate `--owner` and `--repository` usage backwards compatible
- reject malformed qualified repository values
- document the shorthand and its precedence

## Tests

- `/home/openclaw/.pyenv/versions/erp3/bin/python -m unittest discover -s tests -p 'test_*.py' -v` (19 passed)

Requested by: @ecarreras
